### PR TITLE
feat(generators): theme generator to manage workspace themes

### DIFF
--- a/.claude/skills/scaffoldizr/SKILL.md
+++ b/.claude/skills/scaffoldizr/SKILL.md
@@ -65,7 +65,7 @@ All prompt questions can be answered via CLI flags using `--parameter "value"` o
 | `view` | `--viewType`, `--viewName`, `--viewDescription` |
 | `constant` | `--constantName`, `--constantValue` |
 | `archetype` | `--archetypeName`, `--archetypeDescription` |
-| `theme` | `--themeAction "Add themes" --additionalThemes '["<url>"]'` |
+| `theme` | `--themeAction "Add themes" --additionalThemes "<url1>,<url2>"` |
 
 Each element file documents the specific flags and CLI command for that generator.
 
@@ -155,11 +155,11 @@ Use the `theme` generator to add, remove, or list workspace themes. The `theme` 
 ```bash
 scfz theme \
   --themeAction "Add themes" \
-  --additionalThemes '["https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json"]'
+  --additionalThemes "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json"
 ```
 
 - `--themeAction`: `"Add themes"` | `"Remove themes"` | `"List themes"`
-- `--additionalThemes`: JSON array of theme URLs to add
+- `--additionalThemes`: comma-separated theme URLs to add
 - Color themes (Blue, Red, Green, Yellow) are mutually exclusive — selecting a new color replaces the existing one
 
 ## Use Structurizr CLI commands to interact with the workspace

--- a/.claude/skills/scaffoldizr/SKILL.md
+++ b/.claude/skills/scaffoldizr/SKILL.md
@@ -65,6 +65,7 @@ All prompt questions can be answered via CLI flags using `--parameter "value"` o
 | `view` | `--viewType`, `--viewName`, `--viewDescription` |
 | `constant` | `--constantName`, `--constantValue` |
 | `archetype` | `--archetypeName`, `--archetypeDescription` |
+| `theme` | `--themeAction "Add themes" --additionalThemes '["<url>"]'` |
 
 Each element file documents the specific flags and CLI command for that generator.
 
@@ -146,6 +147,20 @@ Refer to [relationship](./elements/relationship.md) documentation
 ### View
 
 Refer to [view](./elements/view.md)
+
+### Theme
+
+Use the `theme` generator to add, remove, or list workspace themes. The `theme` generator is available in both Landscape and SoftwareSystem scopes.
+
+```bash
+scfz theme \
+  --themeAction "Add themes" \
+  --additionalThemes '["https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json"]'
+```
+
+- `--themeAction`: `"Add themes"` | `"Remove themes"` | `"List themes"`
+- `--additionalThemes`: JSON array of theme URLs to add
+- Color themes (Blue, Red, Green, Yellow) are mutually exclusive — selecting a new color replaces the existing one
 
 ## Use Structurizr CLI commands to interact with the workspace
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Once a workspace is initialized, use these subcommands:
 | `view` | View | `--viewType` (landscape/deployment), `--viewName`, `--viewDescription` |
 | `constant` | Constant | `--constantName`, `--constantValue` |
 | `archetype` | Archetype | `--archetypeName`, `--archetypeDescription` |
+| `theme` | Manage Themes | `--themeAction "Add themes" --additionalThemes '["<url>"]'` |
 
 ### Scope and Validation Rules
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Once a workspace is initialized, use these subcommands:
 | `view` | View | `--viewType` (landscape/deployment), `--viewName`, `--viewDescription` |
 | `constant` | Constant | `--constantName`, `--constantValue` |
 | `archetype` | Archetype | `--archetypeName`, `--archetypeDescription` |
-| `theme` | Manage Themes | `--themeAction "Add themes" --additionalThemes '["<url>"]'` |
+| `theme` | Manage Themes | `--themeAction "Add themes" --additionalThemes "<url1>,<url2>"` |
 
 ### Scope and Validation Rules
 

--- a/architecture/docs/03-usage.md
+++ b/architecture/docs/03-usage.md
@@ -22,6 +22,7 @@ When you run Scaffoldizr:
 | `🔷 Container` | Creates a deployable/executable unit within a system (web app, database, API, message broker, etc.). Creates container file, view, and relationship files. Supports types: EventBus, MessageBroker, Function, Database, WebApp, MobileApp. | Parent system, container name, description, type, technology, relationships |
 | `🔹 Component` | Creates a component within a container (controller, service, repository, etc.). Requires at least one existing container. Creates/updates component files, includes, views, and relationships. | Parent container, component name, description, technology, relationships |
 | `🔳 View` | Creates Structurizr views for visualizing architecture. Supports Deployment and Landscape view types. Creates view files and environment configurations. See [Supported View Types](#supported-view-types) below. | View type, system name (if needed), view name, description, instance details (for deployment) |
+| `🎨 Theme` | Manage workspace themes (add, remove, list). Updates the `themes` line in `architecture/workspace.dsl`. Available in both Landscape and SoftwareSystem scopes. | `themeAction`, `additionalThemes` |
 
 ## Supported View Types
 
@@ -76,6 +77,7 @@ Once a workspace is initialized, use these subcommands:
 | `view` | View | `--viewType` (landscape/deployment), `--viewName`, `--viewDescription` |
 | `constant` | Constant | `--constantName`, `--constantValue` |
 | `archetype` | Archetype | `--archetypeName`, `--archetypeDescription` |
+| `theme` | Manage Themes | `--themeAction "Add themes" --additionalThemes '["<url>"]'` |
 
 ### Scope and Validation Rules
 
@@ -84,5 +86,6 @@ Once a workspace is initialized, use these subcommands:
   * **SoftwareSystem**: Allows `container`, `component`, `person`, `external-system`, `view`, `relationship`, `constant`, `archetype`.
   * Using an unsupported generator for the current scope will result in a non-zero exit code.
 * **Uniqueness Validation**: Element names must be unique. If a duplicate name is provided in non-interactive mode, the command will fail with exit code 1.
+* **Color Theme Exclusivity**: The `theme` generator enforces that only one color-based theme (Blue, Red, Green, Yellow) can be active at a time. Selecting a new color theme automatically replaces the existing one.
 * **Decisions Folder**: Every scaffolded workspace includes an `architecture/decisions/` folder for Architecture Decision Records (ADRs).
 

--- a/architecture/docs/03-usage.md
+++ b/architecture/docs/03-usage.md
@@ -77,7 +77,7 @@ Once a workspace is initialized, use these subcommands:
 | `view` | View | `--viewType` (landscape/deployment), `--viewName`, `--viewDescription` |
 | `constant` | Constant | `--constantName`, `--constantValue` |
 | `archetype` | Archetype | `--archetypeName`, `--archetypeDescription` |
-| `theme` | Manage Themes | `--themeAction "Add themes" --additionalThemes '["<url>"]'` |
+| `theme` | Manage Themes | `--themeAction "Add themes" --additionalThemes "<url1>,<url2>"` |
 
 ### Scope and Validation Rules
 

--- a/architecture/docs/06-themes.md
+++ b/architecture/docs/06-themes.md
@@ -19,14 +19,14 @@ Color-based themes (Blue, Red, Green, Yellow) are mutually exclusive. Selecting 
 Use the `theme` subcommand with flags for automation:
 
 - `--themeAction`: one of `"Add themes"`, `"Remove themes"`, or `"List themes"`.
-- `--additionalThemes`: a JSON array of theme URLs to add.
+- `--additionalThemes`: comma-separated theme URLs to add (e.g. `"url1,url2"`).
 
 For example, to add the Shapes theme:
 
 ```bash
 scfz theme \
   --themeAction "Add themes" \
-  --additionalThemes '["https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json"]'
+  --additionalThemes "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json"
 ```
 
 The Blue color theme, which is not included by default during workspace initialization, can be added using:
@@ -34,7 +34,7 @@ The Blue color theme, which is not included by default during workspace initiali
 ```bash
 scfz theme \
   --themeAction "Add themes" \
-  --additionalThemes '["https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-blue.json"]'
+  --additionalThemes "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-blue.json"
 ```
 
 ## Available Themes

--- a/architecture/docs/06-themes.md
+++ b/architecture/docs/06-themes.md
@@ -1,5 +1,44 @@
 
+
+## Managing Themes with Scaffoldizr
+
+Use the `theme` generator to manage your workspace themes without manually editing the DSL.
+
+### Interactive
+
+Run `scfz theme` to launch the interactive theme manager. It provides three actions:
+
+- **Add themes**: select from built-in themes or enter a custom URL.
+- **Remove themes**: select currently configured themes to remove.
+- **List themes**: see all theme URLs currently used in your workspace.
+
+Color-based themes (Blue, Red, Green, Yellow) are mutually exclusive. Selecting a new color theme automatically replaces any existing one.
+
+### Non-Interactive (AI Agent Mode)
+
+Use the `theme` subcommand with flags for automation:
+
+- `--themeAction`: one of `"Add themes"`, `"Remove themes"`, or `"List themes"`.
+- `--additionalThemes`: a JSON array of theme URLs to add.
+
+For example, to add the Shapes theme:
+
+```bash
+scfz theme \
+  --themeAction "Add themes" \
+  --additionalThemes '["https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json"]'
+```
+
+The Blue color theme, which is not included by default during workspace initialization, can be added using:
+
+```bash
+scfz theme \
+  --themeAction "Add themes" \
+  --additionalThemes '["https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-blue.json"]'
+```
+
 ## Available Themes
+
 
 Scaffoldizr includes some extra themes extending from the default Structurizr theme. [More information here](https://docs.structurizr.com/ui/diagrams/themes).
 

--- a/e2e/scfz-archetypes.test.ts
+++ b/e2e/scfz-archetypes.test.ts
@@ -296,6 +296,7 @@ describe("e2e: archetypes", () => {
 
             loop(proc, [
                 keypress.UP,
+                keypress.UP,
                 keypress.ENTER,
                 keypress.ENTER,
                 keypress.SPACE,
@@ -518,6 +519,7 @@ describe("e2e: archetypes", () => {
             });
 
             loop(proc, [
+                keypress.UP,
                 keypress.UP,
                 keypress.ENTER,
                 keypress.ENTER,

--- a/e2e/scfz-softwaresystem.test.ts
+++ b/e2e/scfz-softwaresystem.test.ts
@@ -245,6 +245,7 @@ describe("e2e: Software System", () => {
 
         loop(proc, [
             keypress.UP,
+            keypress.UP,
             keypress.ENTER,
             keypress.ENTER,
             keypress.SPACE,

--- a/lib/generators/index.ts
+++ b/lib/generators/index.ts
@@ -6,6 +6,7 @@ export { default as extSystemGenerator } from "./external-system";
 export { default as personGenerator } from "./person";
 export { default as relationshipGenerator } from "./relationship";
 export { default as systemGenerator } from "./system";
+export { default as themeGenerator } from "./theme";
 export { default as viewGenerator } from "./view";
 export { default as workspaceGenerator } from "./workspace";
 

--- a/lib/generators/theme.ts
+++ b/lib/generators/theme.ts
@@ -1,0 +1,156 @@
+import { join } from "node:path";
+import { file, write } from "bun";
+import { ActionTypes, type ReplaceAction } from "../utils/actions";
+import { getWorkspaceThemes } from "../utils/dsl";
+import type { GeneratorDefinition } from "../utils/generator";
+import { Elements } from "../utils/labels";
+import { checkbox, input, select } from "../utils/prompts";
+import { BUILTIN_THEMES, COLOR_THEME_URLS } from "../utils/themes";
+
+type ThemeAnswers = {
+    selectedThemes: string[];
+};
+
+const generator: GeneratorDefinition<ThemeAnswers> = {
+    name: Elements.Theme,
+    description: "Manage workspace themes",
+    questions: async (generator) => {
+        const workspaceDslPath = join(
+            generator.destPath,
+            "architecture/workspace.dsl",
+        );
+
+        const themeAction = await select({
+            name: "themeAction",
+            message: "What do you want to do?",
+            choices: ["Add themes", "Remove themes", "List themes"],
+        });
+
+        if (themeAction === "List themes") {
+            const selectedThemes = await getWorkspaceThemes(workspaceDslPath);
+
+            if (selectedThemes.length === 0) {
+                console.log("No themes configured in workspace.dsl");
+            } else {
+                console.log("Current themes:");
+                for (const themeUrl of selectedThemes) {
+                    console.log(`- ${themeUrl}`);
+                }
+            }
+
+            return { selectedThemes: [] };
+        }
+
+        if (themeAction === "Add themes") {
+            const selectedThemes = await checkbox({
+                name: "additionalThemes",
+                message: "Select themes to add:",
+                choices: BUILTIN_THEMES,
+            });
+
+            let customThemeUrl = "";
+            if (selectedThemes.includes("custom")) {
+                customThemeUrl = await input({
+                    name: "customThemeUrl",
+                    message: "Custom theme URL:",
+                    validate: (value: string) => {
+                        const trimmedValue = value.trim();
+
+                        if (trimmedValue.length === 0)
+                            return "Custom theme URL is required";
+
+                        return /^https?:\/\/.+/.test(trimmedValue)
+                            ? true
+                            : "Enter a valid URL starting with http:// or https://";
+                    },
+                });
+            }
+
+            const currentThemes = await getWorkspaceThemes(workspaceDslPath);
+            const newSelectionHasColor =
+                selectedThemes.some((t) =>
+                    (COLOR_THEME_URLS as string[]).includes(t),
+                ) ||
+                (customThemeUrl.trim().length > 0 &&
+                    (COLOR_THEME_URLS as string[]).includes(
+                        customThemeUrl.trim(),
+                    ));
+
+            const baseThemes = newSelectionHasColor
+                ? currentThemes.filter(
+                      (t) => !(COLOR_THEME_URLS as string[]).includes(t),
+                  )
+                : currentThemes;
+
+            const finalSelectedThemes = Array.from(
+                new Set([
+                    ...baseThemes,
+                    ...selectedThemes.filter((theme) => theme !== "custom"),
+                    ...(customThemeUrl.trim().length > 0
+                        ? [customThemeUrl.trim()]
+                        : []),
+                ]),
+            );
+
+            if (finalSelectedThemes.length === 0) {
+                console.log(
+                    "No themes selected. Existing themes will stay unchanged",
+                );
+            }
+
+            return {
+                selectedThemes: finalSelectedThemes,
+            };
+        }
+
+        const currentThemes = await getWorkspaceThemes(workspaceDslPath);
+
+        if (currentThemes.length === 0) {
+            console.log("No themes configured in workspace.dsl");
+            return { selectedThemes: [] };
+        }
+
+        const themesToRemove = await checkbox({
+            name: "themesToRemove",
+            message: "Select themes to remove:",
+            choices: currentThemes.map((themeUrl) => ({
+                name: themeUrl,
+                value: themeUrl,
+            })),
+        });
+
+        if (themesToRemove.length === 0) {
+            console.log(
+                "No themes selected for removal. Existing themes will stay unchanged",
+            );
+        }
+
+        const selectedThemes = currentThemes.filter(
+            (themeUrl) => !themesToRemove.includes(themeUrl),
+        );
+
+        if (themesToRemove.length > 0 && selectedThemes.length === 0) {
+            const dslContent = await file(workspaceDslPath).text();
+            const cleaned = dslContent.replace(
+                /[ \t]*themes(?:\s+"[^"]*")*\n?/,
+                "",
+            );
+            await write(workspaceDslPath, cleaned);
+            console.log("All themes removed from workspace.dsl");
+            return { selectedThemes: [] };
+        }
+
+        return { selectedThemes };
+    },
+    actions: [
+        {
+            type: ActionTypes.Replace,
+            path: "architecture/workspace.dsl",
+            pattern: /themes(?:\s+"[^"]*")*/,
+            templateFile: "templates/theme.hbs",
+            when: (answers) => answers.selectedThemes.length > 0,
+        } as ReplaceAction<ThemeAnswers>,
+    ],
+};
+
+export default generator;

--- a/lib/generators/theme.ts
+++ b/lib/generators/theme.ts
@@ -1,6 +1,10 @@
 import { join } from "node:path";
 import { file, write } from "bun";
-import { ActionTypes, type ReplaceAction } from "../utils/actions";
+import {
+    ActionTypes,
+    type AppendAction,
+    type ReplaceAction,
+} from "../utils/actions";
 import { getWorkspaceThemes } from "../utils/dsl";
 import type { GeneratorDefinition } from "../utils/generator";
 import { Elements } from "../utils/labels";
@@ -9,6 +13,7 @@ import { BUILTIN_THEMES, COLOR_THEME_URLS } from "../utils/themes";
 
 type ThemeAnswers = {
     selectedThemes: string[];
+    hasExistingThemesLine: boolean;
 };
 
 const generator: GeneratorDefinition<ThemeAnswers> = {
@@ -38,7 +43,7 @@ const generator: GeneratorDefinition<ThemeAnswers> = {
                 }
             }
 
-            return { selectedThemes: [] };
+            return { selectedThemes: [], hasExistingThemesLine: false };
         }
 
         if (themeAction === "Add themes") {
@@ -98,8 +103,14 @@ const generator: GeneratorDefinition<ThemeAnswers> = {
                 );
             }
 
+            const dslContent = await file(workspaceDslPath).text();
+            const hasExistingThemesLine = /themes(?:\s+"[^"]*")*/.test(
+                dslContent,
+            );
+
             return {
                 selectedThemes: finalSelectedThemes,
+                hasExistingThemesLine,
             };
         }
 
@@ -107,7 +118,7 @@ const generator: GeneratorDefinition<ThemeAnswers> = {
 
         if (currentThemes.length === 0) {
             console.log("No themes configured in workspace.dsl");
-            return { selectedThemes: [] };
+            return { selectedThemes: [], hasExistingThemesLine: false };
         }
 
         const themesToRemove = await checkbox({
@@ -137,10 +148,10 @@ const generator: GeneratorDefinition<ThemeAnswers> = {
             );
             await write(workspaceDslPath, cleaned);
             console.log("All themes removed from workspace.dsl");
-            return { selectedThemes: [] };
+            return { selectedThemes: [], hasExistingThemesLine: false };
         }
 
-        return { selectedThemes };
+        return { selectedThemes, hasExistingThemesLine: true };
     },
     actions: [
         {
@@ -148,8 +159,19 @@ const generator: GeneratorDefinition<ThemeAnswers> = {
             path: "architecture/workspace.dsl",
             pattern: /themes(?:\s+"[^"]*")*/,
             templateFile: "templates/theme.hbs",
-            when: (answers) => answers.selectedThemes.length > 0,
+            when: (answers) =>
+                answers.selectedThemes.length > 0 &&
+                answers.hasExistingThemesLine,
         } as ReplaceAction<ThemeAnswers>,
+        {
+            type: ActionTypes.Append,
+            path: "architecture/workspace.dsl",
+            pattern: /views\s*\{/,
+            templateFile: "templates/theme.hbs",
+            when: (answers) =>
+                answers.selectedThemes.length > 0 &&
+                !answers.hasExistingThemesLine,
+        } as AppendAction<ThemeAnswers>,
     ],
 };
 

--- a/lib/generators/workspace.ts
+++ b/lib/generators/workspace.ts
@@ -4,6 +4,14 @@ import type { GeneratorDefinition } from "../utils/generator";
 import { Elements } from "../utils/labels";
 import { checkbox, confirm, input, select } from "../utils/prompts";
 import { stringEmpty } from "../utils/questions/validators";
+import {
+    SCAFFOLDIZR_GREEN_THEME_URL,
+    SCAFFOLDIZR_RED_THEME_URL,
+    SCAFFOLDIZR_SHAPES_THEME_URL,
+    SCAFFOLDIZR_STATUS_THEME_URL,
+    SCAFFOLDIZR_YELLOW_THEME_URL,
+    STRUCTURIZR_DEFAULT_THEME_URL,
+} from "../utils/themes";
 
 const globalUserName =
     await $`git config --global user.name || echo "(no name)"`.text();
@@ -92,11 +100,11 @@ const generator: GeneratorDefinition<WorkspaceAnswers> = {
                   choices: [
                       {
                           name: "Shapes (Scaffoldizr)",
-                          value: "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json",
+                          value: SCAFFOLDIZR_SHAPES_THEME_URL,
                       },
                       {
                           name: "Status (Scaffoldizr)",
-                          value: "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-status.json",
+                          value: SCAFFOLDIZR_STATUS_THEME_URL,
                       },
                   ],
               })
@@ -110,15 +118,15 @@ const generator: GeneratorDefinition<WorkspaceAnswers> = {
                       { name: "Blue (Default)", value: undefined },
                       {
                           name: "Red",
-                          value: "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-red.json",
+                          value: SCAFFOLDIZR_RED_THEME_URL,
                       },
                       {
                           name: "Green",
-                          value: "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-green.json",
+                          value: SCAFFOLDIZR_GREEN_THEME_URL,
                       },
                       {
                           name: "Yellow",
-                          value: "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-yellow.json",
+                          value: SCAFFOLDIZR_YELLOW_THEME_URL,
                       },
                   ],
               })
@@ -133,9 +141,11 @@ const generator: GeneratorDefinition<WorkspaceAnswers> = {
             authorName,
             authorEmail,
             shouldIncludeTheme,
-            additionalThemes: [...additionalThemes, mainColor].filter(
-                Boolean,
-            ) as string[],
+            additionalThemes: [
+                STRUCTURIZR_DEFAULT_THEME_URL,
+                ...additionalThemes,
+                mainColor,
+            ].filter(Boolean) as string[],
         };
     },
     actions: [

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -113,6 +113,7 @@ Let's create a new one by answering the questions below.
             Elements.DeploymentNode,
             Elements.Person,
             Elements.Relationship,
+            Elements.Theme,
         ];
 
         if (workspaceInfo.configuration.scope === "Landscape") {

--- a/lib/templates/bundle.ts
+++ b/lib/templates/bundle.ts
@@ -17,6 +17,7 @@ import systemExternal from "./system/external.hbs";
 import systemPerson from "./system/person.hbs";
 import systemSystem from "./system/system.hbs";
 import testTemplate from "./test-template.hbs";
+import themeTemplate from "./theme.hbs";
 import viewsComponent from "./views/component.hbs";
 import viewsContainer from "./views/container.hbs";
 import viewsDeployment from "./views/deployment.hbs";
@@ -50,6 +51,7 @@ const templatesMap = new Map([
     ["templates/system/external.hbs", systemExternal],
     ["templates/system/person.hbs", systemPerson],
     ["templates/system/system.hbs", systemSystem],
+    ["templates/theme.hbs", themeTemplate],
     ["templates/test-template.hbs", testTemplate],
     ["templates/views/component.hbs", viewsComponent],
     ["templates/views/container.hbs", viewsContainer],

--- a/lib/templates/theme.hbs
+++ b/lib/templates/theme.hbs
@@ -1,0 +1,1 @@
+themes{{#each selectedThemes}} "{{this}}"{{/each}}

--- a/lib/templates/workspace.hbs
+++ b/lib/templates/workspace.hbs
@@ -24,7 +24,7 @@ workspace "{{{workspaceName}}}" {
 
     views {
         {{#if shouldIncludeTheme}}
-        themes "https://static.structurizr.com/themes/default/theme.json"{{#each additionalThemes}} "{{this}}" {{/each}}{{/if}}
+        themes{{#each additionalThemes}} "{{this}}"{{/each}}{{/if}}
         !const AUTHOR "Author: {{{authorName}}} <{{authorEmail}}>"
 
         !include views

--- a/lib/utils/actions/index.ts
+++ b/lib/utils/actions/index.ts
@@ -2,6 +2,7 @@ export enum ActionTypes {
     Add = "add",
     AddMany = "addMany",
     Append = "append",
+    Replace = "replace",
 }
 
 declare function whenOrSkip<A extends Record<string, unknown>>(
@@ -22,3 +23,4 @@ export type ExtendedAction = {
 export * from "./add";
 export * from "./add-many";
 export * from "./append";
+export * from "./replace";

--- a/lib/utils/actions/replace.test.ts
+++ b/lib/utils/actions/replace.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { resolve } from "node:path";
+import { file, write } from "bun";
+import templates from "../../templates/bundle";
+import { ActionTypes } from ".";
+import { replace } from "./replace";
+
+describe("actions", () => {
+    describe("replace", () => {
+        test("should replace matched line", async () => {
+            const initialContent = "Content 1\ncontent 2\ncontent 3";
+            const testFilePath = resolve(
+                import.meta.dirname,
+                ".test-generated/replace/replace-test.txt",
+            );
+
+            await write(testFilePath, initialContent);
+
+            const result = await replace(
+                {
+                    type: ActionTypes.Replace,
+                    rootPath: import.meta.dirname,
+                    templates,
+                    path: testFilePath,
+                    pattern: /content 2/,
+                    templateFile: "templates/test-template.hbs",
+                },
+                { filename: "Append test" },
+            );
+
+            expect(result).toBeTrue();
+            const fileContents = await file(testFilePath).text();
+            expect(fileContents).toEqual(
+                "Content 1\ntemplate append-test\ncontent 3",
+            );
+        });
+
+        test("should warn when no match found and not modify file", async () => {
+            const initialContent = "Content 1\ncontent 2\ncontent 3";
+            const testFilePath = resolve(
+                import.meta.dirname,
+                ".test-generated/replace/replace-test-2.txt",
+            );
+
+            await write(testFilePath, initialContent);
+            const consoleLogSpy = spyOn(console, "log").mockImplementation(
+                () => {},
+            );
+
+            const result = await replace(
+                {
+                    type: ActionTypes.Replace,
+                    rootPath: import.meta.dirname,
+                    templates,
+                    path: testFilePath,
+                    pattern: /content 4/,
+                    templateFile: "templates/test-template.hbs",
+                },
+                { filename: "Append test" },
+            );
+
+            expect(result).toBeFalse();
+            const fileContents = await file(testFilePath).text();
+            expect(fileContents).toEqual(initialContent);
+            expect(consoleLogSpy).toHaveBeenCalled();
+
+            consoleLogSpy.mockRestore();
+        });
+
+        test("should skip if when() is declared", async () => {
+            const initialContent = "Content 1\ncontent 2\ncontent 3";
+            const testFilePath = resolve(
+                import.meta.dirname,
+                ".test-generated/replace/replace-test-3.txt",
+            );
+
+            await write(testFilePath, initialContent);
+
+            const result = await replace(
+                {
+                    type: ActionTypes.Replace,
+                    when: async ({ doCreate }) => !doCreate,
+                    rootPath: import.meta.dirname,
+                    templates,
+                    path: testFilePath,
+                    pattern: /content 2/,
+                    templateFile: "templates/test-template.hbs",
+                },
+                { filename: "Append test", doCreate: true },
+            );
+
+            expect(result).toBeFalse();
+            const fileContents = await file(testFilePath).text();
+            expect(fileContents).toEqual(initialContent);
+        });
+
+        test("should skip if skip() is declared", async () => {
+            const initialContent = "Content 1\ncontent 2\ncontent 3";
+            const testFilePath = resolve(
+                import.meta.dirname,
+                ".test-generated/replace/replace-test-4.txt",
+            );
+
+            await write(testFilePath, initialContent);
+
+            const result = await replace(
+                {
+                    type: ActionTypes.Replace,
+                    skip: ({ doNotCreate }) => doNotCreate,
+                    rootPath: import.meta.dirname,
+                    templates,
+                    path: testFilePath,
+                    pattern: /content 2/,
+                    templateFile: "templates/test-template.hbs",
+                },
+                { filename: "Append test", doNotCreate: true },
+            );
+
+            expect(result).toBeFalse();
+            const fileContents = await file(testFilePath).text();
+            expect(fileContents).toEqual(initialContent);
+        });
+    });
+});

--- a/lib/utils/actions/replace.ts
+++ b/lib/utils/actions/replace.ts
@@ -1,0 +1,91 @@
+import { access } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+import { file, write } from "bun";
+import chalk from "chalk";
+import { compileSource, compileTemplateFile } from "../handlebars";
+import type { ActionTypes, BaseAction, ExtendedAction } from ".";
+
+export type ReplaceAction<A extends Record<string, unknown>> = BaseAction<A> & {
+    type: ActionTypes.Replace;
+    templateFile: string;
+    path: string;
+    pattern: RegExp;
+    filePermissions?: string;
+};
+
+export async function replace<A extends Record<string, unknown>>(
+    options: ExtendedAction & ReplaceAction<A>,
+    answers: A,
+): Promise<boolean> {
+    const {
+        templates,
+        rootPath,
+        when = () => true,
+        skip = () => false,
+        ...opts
+    } = options;
+
+    const [doWhen, doSkip] = await Promise.all([
+        when(answers, rootPath),
+        skip(answers, rootPath),
+    ]);
+
+    const shouldSkip = doSkip || !doWhen;
+
+    if (shouldSkip) {
+        console.log(
+            `${chalk.gray("[SKIPPED]:")} ${
+                typeof shouldSkip === "string"
+                    ? shouldSkip
+                    : resolve(rootPath, options.path)
+            }`,
+        );
+        return false;
+    }
+
+    const compiledOpts = compileSource<ReplaceAction<A>>(opts, answers);
+    const targetFilePath = resolve(rootPath, compiledOpts.path);
+    const relativePath = relative(process.cwd(), targetFilePath);
+    const targetFile = file(targetFilePath);
+
+    const templateLocation = templates.get(compiledOpts.templateFile);
+
+    if (!templateLocation) {
+        throw new Error(`Template not found: ${compiledOpts.templateFile}`);
+    }
+
+    try {
+        await access(targetFilePath);
+    } catch {
+        throw new Error(`File not found: ${targetFilePath}`);
+    }
+
+    const templatePromise = compileTemplateFile(
+        templateLocation,
+        answers,
+        rootPath,
+    );
+    const fileContentsPromise = targetFile.text();
+
+    const [template, fileContents] = await Promise.all([
+        templatePromise,
+        fileContentsPromise,
+    ]);
+
+    const [match] = fileContents.match(compiledOpts.pattern) ?? [];
+
+    if (!match) {
+        console.log(
+            `${chalk.yellow("[WARN]:")} ${relativePath} - No matches for pattern ${compiledOpts.pattern.toString()}`,
+        );
+        return false;
+    }
+
+    const newContent = fileContents.replace(match, template);
+
+    await write(targetFilePath, newContent);
+
+    console.log(`${chalk.gray("[UPDATED]:")} ${relativePath}`);
+
+    return true;
+}

--- a/lib/utils/actions/replace.ts
+++ b/lib/utils/actions/replace.ts
@@ -10,7 +10,6 @@ export type ReplaceAction<A extends Record<string, unknown>> = BaseAction<A> & {
     templateFile: string;
     path: string;
     pattern: RegExp;
-    filePermissions?: string;
 };
 
 export async function replace<A extends Record<string, unknown>>(
@@ -72,16 +71,21 @@ export async function replace<A extends Record<string, unknown>>(
         fileContentsPromise,
     ]);
 
-    const [match] = fileContents.match(compiledOpts.pattern) ?? [];
+    const matchResult = fileContents.match(compiledOpts.pattern);
 
-    if (!match) {
+    if (!matchResult || matchResult.index === undefined) {
         console.log(
             `${chalk.yellow("[WARN]:")} ${relativePath} - No matches for pattern ${compiledOpts.pattern.toString()}`,
         );
         return false;
     }
 
-    const newContent = fileContents.replace(match, template);
+    const match = matchResult[0];
+    const matchIndex = matchResult.index;
+    const newContent =
+        fileContents.slice(0, matchIndex) +
+        template +
+        fileContents.slice(matchIndex + match.length);
 
     await write(targetFilePath, newContent);
 

--- a/lib/utils/dsl.test.ts
+++ b/lib/utils/dsl.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { write } from "bun";
 import { getWorkspaceThemes } from "./dsl";
 
-const testArtifactsRootFolderPath = join("/tmp", "scaffoldizr-dsl-test");
+const testArtifactsRootFolderPath = join(tmpdir(), "scaffoldizr-dsl-test");
 const createdWorkspaceDslFilePaths: string[] = [];
 
 const createWorkspaceDslFileWithContent = async (

--- a/lib/utils/dsl.test.ts
+++ b/lib/utils/dsl.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { write } from "bun";
+import { getWorkspaceThemes } from "./dsl";
+
+const testArtifactsRootFolderPath = join("/tmp", "scaffoldizr-dsl-test");
+const createdWorkspaceDslFilePaths: string[] = [];
+
+const createWorkspaceDslFileWithContent = async (
+    workspaceDslContent: string,
+): Promise<string> => {
+    const temporaryWorkspaceDslFilePath = join(
+        testArtifactsRootFolderPath,
+        `${randomUUID()}.dsl`,
+    );
+    await write(temporaryWorkspaceDslFilePath, workspaceDslContent);
+    createdWorkspaceDslFilePaths.push(temporaryWorkspaceDslFilePath);
+    return temporaryWorkspaceDslFilePath;
+};
+
+afterEach(async () => {
+    await Promise.all(
+        createdWorkspaceDslFilePaths
+            .splice(0)
+            .map((workspaceDslFilePath) =>
+                rm(workspaceDslFilePath, { force: true }),
+            ),
+    );
+    await rm(testArtifactsRootFolderPath, { recursive: true, force: true });
+});
+
+describe("getWorkspaceThemes", () => {
+    test("returns all theme URLs when themes line exists", async () => {
+        const workspaceDslFilePath = await createWorkspaceDslFileWithContent(
+            `workspace "Test" {\n    views {\n        themes "https://example.com/theme-1.json" "https://example.com/theme-2.json" "https://example.com/theme-3.json"\n    }\n}`,
+        );
+
+        const workspaceThemes = await getWorkspaceThemes(workspaceDslFilePath);
+
+        expect(workspaceThemes).toEqual([
+            "https://example.com/theme-1.json",
+            "https://example.com/theme-2.json",
+            "https://example.com/theme-3.json",
+        ]);
+    });
+
+    test("returns empty array when themes line is missing", async () => {
+        const workspaceDslFilePath = await createWorkspaceDslFileWithContent(
+            `workspace "Test" {\n    views {\n        !include views\n    }\n}`,
+        );
+
+        const workspaceThemes = await getWorkspaceThemes(workspaceDslFilePath);
+
+        expect(workspaceThemes).toEqual([]);
+    });
+
+    test("throws clear error when file does not exist", async () => {
+        const missingWorkspaceDslFilePath = join(
+            testArtifactsRootFolderPath,
+            "missing-workspace.dsl",
+        );
+
+        await expect(
+            getWorkspaceThemes(missingWorkspaceDslFilePath),
+        ).rejects.toThrow(
+            `Workspace DSL file not found: ${missingWorkspaceDslFilePath}`,
+        );
+    });
+});

--- a/lib/utils/dsl.ts
+++ b/lib/utils/dsl.ts
@@ -1,0 +1,31 @@
+import { file } from "bun";
+
+export const getWorkspaceThemes = async (
+    workspaceDslPath: string,
+): Promise<string[]> => {
+    const workspaceFile = file(workspaceDslPath);
+
+    if (!(await workspaceFile.exists())) {
+        throw new Error(`Workspace DSL file not found: ${workspaceDslPath}`);
+    }
+
+    const workspaceDslContent = await workspaceFile.text();
+    const themesMatch = workspaceDslContent.match(/themes\s+((?:"[^"]*"\s*)+)/);
+
+    if (!themesMatch) {
+        return [];
+    }
+
+    const capturedThemes = themesMatch[1];
+    const extractedThemes: string[] = [];
+
+    for (const extractedThemeMatch of capturedThemes.matchAll(/"([^"]*)"/g)) {
+        const extractedThemeUrl = extractedThemeMatch[1];
+
+        if (typeof extractedThemeUrl === "string") {
+            extractedThemes.push(extractedThemeUrl);
+        }
+    }
+
+    return extractedThemes;
+};

--- a/lib/utils/generator.ts
+++ b/lib/utils/generator.ts
@@ -4,8 +4,9 @@ import type {
     AddManyAction,
     AppendAction,
     ExtendedAction,
+    ReplaceAction,
 } from "./actions";
-import { ActionTypes, add, addMany, append } from "./actions";
+import { ActionTypes, add, addMany, append, replace } from "./actions";
 
 /**
  * Added support for latest inquirer API
@@ -22,7 +23,12 @@ export type GeneratorDefinition<
     name: string;
     description: string;
     questions: ((generator: Generator<A>) => Promise<A>) | QuestionsObject;
-    actions: (AddAction<A> | AddManyAction<A> | AppendAction<A>)[];
+    actions: (
+        | AddAction<A>
+        | AddManyAction<A>
+        | AppendAction<A>
+        | ReplaceAction<A>
+    )[];
 };
 
 export type Generator<A extends Record<string, unknown>> =
@@ -36,7 +42,7 @@ export type GetAnswers<Type> =
 
 async function executeAction<A extends Record<string, unknown>>(
     action: ExtendedAction &
-        (AddAction<A> | AddManyAction<A> | AppendAction<A>),
+        (AddAction<A> | AddManyAction<A> | AppendAction<A> | ReplaceAction<A>),
     answers: A,
 ): Promise<boolean> {
     switch (action.type) {
@@ -48,6 +54,9 @@ async function executeAction<A extends Record<string, unknown>>(
         }
         case ActionTypes.Append: {
             return append(action, answers);
+        }
+        case ActionTypes.Replace: {
+            return replace(action, answers);
         }
         default: {
             throw new Error("Action not found");

--- a/lib/utils/labels.ts
+++ b/lib/utils/labels.ts
@@ -9,6 +9,7 @@ export enum Labels {
     DeploymentNode = "🟧",
     Relationship = "⇢ ",
     View = "🔳",
+    Theme = "🎨",
 }
 
 export enum Elements {
@@ -23,6 +24,7 @@ export enum Elements {
     Relationship = "Relationship",
     View = "View",
     Workspace = "Workspace",
+    Theme = "Theme",
 }
 
 export const Folders = {
@@ -45,6 +47,7 @@ export const SORTED_GENERATOR_AVAILABLE_ELEMENTS: string[] = [
     Elements.Component,
     Elements.View,
     Elements.Relationship,
+    Elements.Theme,
 ];
 
 export const labelElementByTags = (tags = ""): string => {

--- a/lib/utils/themes.ts
+++ b/lib/utils/themes.ts
@@ -1,0 +1,34 @@
+export const STRUCTURIZR_DEFAULT_THEME_URL =
+    "https://static.structurizr.com/themes/default/theme.json";
+export const SCAFFOLDIZR_SHAPES_THEME_URL =
+    "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json";
+export const SCAFFOLDIZR_STATUS_THEME_URL =
+    "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-status.json";
+export const SCAFFOLDIZR_BLUE_THEME_URL =
+    "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-blue.json";
+export const SCAFFOLDIZR_RED_THEME_URL =
+    "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-red.json";
+export const SCAFFOLDIZR_GREEN_THEME_URL =
+    "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-green.json";
+export const SCAFFOLDIZR_YELLOW_THEME_URL =
+    "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-yellow.json";
+
+export const COLOR_THEME_URLS: readonly string[] = [
+    SCAFFOLDIZR_BLUE_THEME_URL,
+    SCAFFOLDIZR_RED_THEME_URL,
+    SCAFFOLDIZR_GREEN_THEME_URL,
+    SCAFFOLDIZR_YELLOW_THEME_URL,
+];
+
+export type BuiltinTheme = { name: string; value: string };
+
+export const BUILTIN_THEMES: BuiltinTheme[] = [
+    { name: "Default (Structurizr)", value: STRUCTURIZR_DEFAULT_THEME_URL },
+    { name: "Shapes (Scaffoldizr)", value: SCAFFOLDIZR_SHAPES_THEME_URL },
+    { name: "Status (Scaffoldizr)", value: SCAFFOLDIZR_STATUS_THEME_URL },
+    { name: "Blue (Color)", value: SCAFFOLDIZR_BLUE_THEME_URL },
+    { name: "Red (Color)", value: SCAFFOLDIZR_RED_THEME_URL },
+    { name: "Green (Color)", value: SCAFFOLDIZR_GREEN_THEME_URL },
+    { name: "Yellow (Color)", value: SCAFFOLDIZR_YELLOW_THEME_URL },
+    { name: "Custom (by URL)", value: "custom" },
+];


### PR DESCRIPTION
## Summary

Closes #227

Adds a new `theme` generator that allows users to add, remove, and list Structurizr themes in an existing workspace without manually editing DSL files.

## Changes

### New Features
- **`scfz theme` generator** — interactive menu with Add, Remove, and List actions
- **Add themes**: checkbox selection from 7 built-in themes (Default, Shapes, Status, Blue, Red, Green, Yellow) plus a Custom URL option
- **Remove themes**: checkbox of currently configured themes to remove
- **List themes**: prints all active theme URLs from `workspace.dsl`
- **Color theme exclusivity**: selecting a color theme (Blue/Red/Green/Yellow) automatically replaces any existing color theme
- **Workspace init**: default theme prompt now uses the shared `themes.ts` constants

### Infrastructure
- `lib/utils/actions/replace.ts` — new `Replace` action for regex-based in-place substitution in DSL files (with 4 unit tests)
- `lib/utils/dsl.ts` — `getWorkspaceThemes()` utility to parse current themes from `workspace.dsl` (with 3 unit tests)
- `lib/utils/themes.ts` — single source of truth for all 7 built-in theme URLs and constants

### Documentation
- `architecture/docs/06-themes.md` — new "Managing Themes with Scaffoldizr" section (interactive + non-interactive usage)
- `architecture/docs/03-usage.md` — `theme` added to Supported Elements table, Element Generators table, and Scope rules
- `.claude/skills/scaffoldizr/SKILL.md` — `theme` added to element generators reference and new `### Theme` inline section
- `README.md` — `theme` row added to Element Generators table

## Non-Interactive Usage

```bash
# Add a theme
scfz theme \
  --themeAction "Add themes" \
  --additionalThemes 'https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json'

# Add the Blue color theme
scfz theme \
  --themeAction "Add themes" \
  --additionalThemes 'https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-blue.json'

# List current themes
scfz theme --themeAction "List themes"
```

## Test Coverage
- 79/79 unit tests pass
- 4 new tests for the `Replace` action
- 3 new tests for `getWorkspaceThemes()`