### PR TITLE
feat(actions): auto-remove .gitkeep files when scaffolding creates new files

### DIFF
--- a/lib/utils/actions/add-many.test.ts
+++ b/lib/utils/actions/add-many.test.ts
@@ -86,12 +86,12 @@ describe("actions", () => {
                 import.meta.dirname,
                 ".test-generated/decisions/.gitkeep",
             );
-            expect(await file(gitkeepPath1).exists()).toBe(false);
+            expect(await file(gitkeepPath1).exists()).toBe(true);
             const gitkeepPath2 = resolve(
                 import.meta.dirname,
                 ".test-generated/docs/.gitkeep",
             );
-            expect(await file(gitkeepPath2).exists()).toBe(false);
+            expect(await file(gitkeepPath2).exists()).toBe(true);
         });
 
         test("should remove .gitkeep when files are added to directory", async () => {

--- a/lib/utils/actions/add-many.test.ts
+++ b/lib/utils/actions/add-many.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { resolve } from "node:path";
-import { $, file } from "bun";
+import { $, file, write } from "bun";
 import templates from "../../templates/bundle";
 import { ActionTypes } from ".";
 import { addMany } from "./add-many";
@@ -82,17 +82,52 @@ describe("actions", () => {
             );
 
             expect(result).toBeTrue();
-            const generatedFile1 = file(
-                resolve(
-                    import.meta.dirname,
-                    ".test-generated/decisions/.gitkeep",
-                ),
+            const gitkeepPath1 = resolve(
+                import.meta.dirname,
+                ".test-generated/decisions/.gitkeep",
             );
-            expect(generatedFile1.size).toBeGreaterThan(0);
-            const generatedFile2 = file(
-                resolve(import.meta.dirname, ".test-generated/docs/.gitkeep"),
+            expect(await file(gitkeepPath1).exists()).toBe(false);
+            const gitkeepPath2 = resolve(
+                import.meta.dirname,
+                ".test-generated/docs/.gitkeep",
             );
-            expect(generatedFile2.size).toBeGreaterThan(0);
+            expect(await file(gitkeepPath2).exists()).toBe(false);
+        });
+
+        test("should remove .gitkeep when files are added to directory", async () => {
+            const testDir = resolve(
+                import.meta.dirname,
+                ".test-generated/scripts-gitkeep-test",
+            );
+            const scriptsDir = resolve(testDir, "scripts");
+            const gitkeepPath = resolve(scriptsDir, ".gitkeep");
+
+            // Create directory and .gitkeep file
+            await write(gitkeepPath, "");
+
+            // Verify it exists
+            expect(await file(gitkeepPath).exists()).toBe(true);
+
+            // Add files to the directory
+            const result = await addMany(
+                {
+                    type: ActionTypes.AddMany,
+                    templates,
+                    templateFiles: "templates/scripts/**/*.sh",
+                    rootPath: import.meta.dirname,
+                    destination: ".test-generated/scripts-gitkeep-test",
+                },
+                {},
+            );
+
+            expect(result).toBeTrue();
+
+            // Assert .gitkeep is removed
+            expect(await file(gitkeepPath).exists()).toBe(false);
+
+            // Assert .sh files were created
+            const generatedFile = file(resolve(scriptsDir, "update.sh"));
+            expect(generatedFile.size).toBeGreaterThan(0);
         });
 
         test("should skip if when() is declared", async () => {

--- a/lib/utils/actions/add.test.ts
+++ b/lib/utils/actions/add.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { resolve } from "node:path";
-import { file } from "bun";
+import { file, write } from "bun";
 import templates from "../../templates/bundle";
 import { ActionTypes } from ".";
 import { add } from "./add";
@@ -90,6 +90,34 @@ describe("actions", () => {
                 resolve(import.meta.dirname, ".test-generated/test-file-3.txt"),
             );
             expect(generatedFile.size).toEqual(0);
+        });
+
+        test("should remove .gitkeep from grandparent directory", async () => {
+            const rootPath = import.meta.dirname;
+            const gitkeepPath = resolve(rootPath, ".test-generated/.gitkeep");
+
+            // Create .gitkeep file in root directory
+            await write(gitkeepPath, "");
+
+            // Verify it exists
+            expect(await file(gitkeepPath).exists()).toBe(true);
+
+            // Add a file in a subdirectory
+            const result = await add(
+                {
+                    type: ActionTypes.Add,
+                    templates,
+                    templateFile: "templates/test-template.hbs",
+                    rootPath,
+                    path: ".test-generated/subdir/test-file-5.txt",
+                },
+                { filename: "testFile5" },
+            );
+
+            expect(result).toBeTrue();
+
+            // Assert .gitkeep in root is removed
+            expect(await file(gitkeepPath).exists()).toBe(false);
         });
     });
 });

--- a/lib/utils/actions/add.ts
+++ b/lib/utils/actions/add.ts
@@ -1,5 +1,5 @@
 import { chmod } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { basename, dirname, relative, resolve } from "node:path";
 import { file, write } from "bun";
 import chalk from "chalk";
 import { compileSource, compileTemplateFile } from "../handlebars";
@@ -45,12 +45,9 @@ export async function add<A extends Record<string, unknown>>(
     }
 
     const compiledOpts = compileSource<AddAction<A>>(opts, answers);
-    const targetFile = file(resolve(rootPath, compiledOpts.path));
-
-    const relativePath = relative(
-        process.cwd(),
-        resolve(rootPath, compiledOpts.path),
-    );
+    const targetFilePath = resolve(rootPath, compiledOpts.path);
+    const targetFile = file(targetFilePath);
+    const relativePath = relative(process.cwd(), targetFilePath);
 
     if (targetFile.size > 0 && compiledOpts.skipIfExists) {
         console.log(
@@ -73,9 +70,11 @@ export async function add<A extends Record<string, unknown>>(
         rootPath,
     );
 
-    await write(join(rootPath, compiledOpts.path), template);
-    await chmod(join(rootPath, compiledOpts.path), filePermissions);
-    await removeGitkeep(dirname(join(rootPath, compiledOpts.path)), rootPath);
+    await write(targetFilePath, template);
+    await chmod(targetFilePath, filePermissions);
+    if (basename(targetFilePath) !== ".gitkeep") {
+        await removeGitkeep(dirname(targetFilePath), rootPath);
+    }
 
     console.log(`${chalk.gray("[ADDED]:")} ${relativePath}`);
 

--- a/lib/utils/actions/add.ts
+++ b/lib/utils/actions/add.ts
@@ -1,9 +1,10 @@
 import { chmod } from "node:fs/promises";
-import { join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { file, write } from "bun";
 import chalk from "chalk";
 import { compileSource, compileTemplateFile } from "../handlebars";
 import type { ActionTypes, BaseAction, ExtendedAction } from ".";
+import { removeGitkeep } from "./utils";
 
 export type AddAction<A extends Record<string, unknown>> = BaseAction<A> & {
     type: ActionTypes.Add;
@@ -74,7 +75,7 @@ export async function add<A extends Record<string, unknown>>(
 
     await write(join(rootPath, compiledOpts.path), template);
     await chmod(join(rootPath, compiledOpts.path), filePermissions);
-    // await $`chmod ${filePermissions} ${join(rootPath, compiledOpts.path)}`;
+    await removeGitkeep(dirname(join(rootPath, compiledOpts.path)), rootPath);
 
     console.log(`${chalk.gray("[ADDED]:")} ${relativePath}`);
 

--- a/lib/utils/actions/add.ts
+++ b/lib/utils/actions/add.ts
@@ -4,7 +4,7 @@ import { file, write } from "bun";
 import chalk from "chalk";
 import { compileSource, compileTemplateFile } from "../handlebars";
 import type { ActionTypes, BaseAction, ExtendedAction } from ".";
-import { removeGitkeep } from "./utils";
+import { isGitkeep, removeGitkeep } from "./utils";
 
 export type AddAction<A extends Record<string, unknown>> = BaseAction<A> & {
     type: ActionTypes.Add;
@@ -73,9 +73,12 @@ export async function add<A extends Record<string, unknown>>(
         rootPath,
     );
 
-    await write(join(rootPath, compiledOpts.path), template);
-    await chmod(join(rootPath, compiledOpts.path), filePermissions);
-    await removeGitkeep(dirname(join(rootPath, compiledOpts.path)), rootPath);
+    const targetFilePath = join(rootPath, compiledOpts.path);
+    await write(targetFilePath, template);
+    await chmod(targetFilePath, filePermissions);
+    if (!isGitkeep(targetFilePath)) {
+        await removeGitkeep(dirname(targetFilePath), rootPath);
+    }
 
     console.log(`${chalk.gray("[ADDED]:")} ${relativePath}`);
 

--- a/lib/utils/actions/append.test.ts
+++ b/lib/utils/actions/append.test.ts
@@ -172,5 +172,32 @@ describe("actions", () => {
 
             expect(result).toBeFalse();
         });
+        test("should remove .gitkeep from target directory", async () => {
+            const targetDir = resolve(
+                import.meta.dirname,
+                ".test-generated/append",
+            );
+            const gitkeepPath = resolve(targetDir, ".gitkeep");
+
+            await write(gitkeepPath, "");
+            expect(await file(gitkeepPath).exists()).toBe(true);
+
+            const testFilePath = resolve(targetDir, "append-gitkeep-test.txt");
+            await write(testFilePath, "initial content");
+
+            const result = await append(
+                {
+                    type: ActionTypes.Append,
+                    rootPath: import.meta.dirname,
+                    templates,
+                    path: testFilePath,
+                    templateFile: "templates/test-template.hbs",
+                },
+                { filename: "Gitkeep test" },
+            );
+
+            expect(result).toBeTrue();
+            expect(await file(gitkeepPath).exists()).toBe(false);
+        });
     });
 });

--- a/lib/utils/actions/append.ts
+++ b/lib/utils/actions/append.ts
@@ -1,5 +1,5 @@
 import { access, chmod } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { file, write } from "bun";
 import chalk from "chalk";
 import { compileSource, compileTemplateFile } from "../handlebars";
@@ -72,7 +72,9 @@ export async function append<A extends Record<string, unknown>>(
 
         await write(targetFilePath, template);
         await chmod(join(rootPath, compiledOpts.path), filePermissions);
-        await removeGitkeep(dirname(targetFilePath), rootPath);
+        if (basename(targetFilePath) !== ".gitkeep") {
+            await removeGitkeep(dirname(targetFilePath), rootPath);
+        }
 
         console.log(`${chalk.gray("[ADDED]:")} ${relativePath}`);
 
@@ -109,7 +111,9 @@ export async function append<A extends Record<string, unknown>>(
     }
 
     await write(targetFilePath, newContent);
-    await removeGitkeep(dirname(targetFilePath), rootPath);
+    if (basename(targetFilePath) !== ".gitkeep") {
+        await removeGitkeep(dirname(targetFilePath), rootPath);
+    }
 
     console.log(`${chalk.gray("[UPDATED]:")} ${relativePath}`);
 

--- a/lib/utils/actions/append.ts
+++ b/lib/utils/actions/append.ts
@@ -1,9 +1,10 @@
 import { access, chmod } from "node:fs/promises";
-import { join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { file, write } from "bun";
 import chalk from "chalk";
 import { compileSource, compileTemplateFile } from "../handlebars";
 import type { ActionTypes, BaseAction, ExtendedAction } from ".";
+import { removeGitkeep } from "./utils";
 
 export type AppendAction<A extends Record<string, unknown>> = BaseAction<A> & {
     type: ActionTypes.Append;
@@ -71,7 +72,7 @@ export async function append<A extends Record<string, unknown>>(
 
         await write(targetFilePath, template);
         await chmod(join(rootPath, compiledOpts.path), filePermissions);
-        // await $`chmod ${filePermissions} ${join(rootPath, compiledOpts.path)}`;
+        await removeGitkeep(dirname(targetFilePath), rootPath);
 
         console.log(`${chalk.gray("[ADDED]:")} ${relativePath}`);
 
@@ -108,6 +109,7 @@ export async function append<A extends Record<string, unknown>>(
     }
 
     await write(targetFilePath, newContent);
+    await removeGitkeep(dirname(targetFilePath), rootPath);
 
     console.log(`${chalk.gray("[UPDATED]:")} ${relativePath}`);
 

--- a/lib/utils/actions/append.ts
+++ b/lib/utils/actions/append.ts
@@ -4,7 +4,7 @@ import { file, write } from "bun";
 import chalk from "chalk";
 import { compileSource, compileTemplateFile } from "../handlebars";
 import type { ActionTypes, BaseAction, ExtendedAction } from ".";
-import { removeGitkeep } from "./utils";
+import { isGitkeep, removeGitkeep } from "./utils";
 
 export type AppendAction<A extends Record<string, unknown>> = BaseAction<A> & {
     type: ActionTypes.Append;
@@ -72,7 +72,9 @@ export async function append<A extends Record<string, unknown>>(
 
         await write(targetFilePath, template);
         await chmod(join(rootPath, compiledOpts.path), filePermissions);
-        await removeGitkeep(dirname(targetFilePath), rootPath);
+        if (!isGitkeep(targetFilePath)) {
+            await removeGitkeep(dirname(targetFilePath), rootPath);
+        }
 
         console.log(`${chalk.gray("[ADDED]:")} ${relativePath}`);
 
@@ -109,7 +111,9 @@ export async function append<A extends Record<string, unknown>>(
     }
 
     await write(targetFilePath, newContent);
-    await removeGitkeep(dirname(targetFilePath), rootPath);
+    if (!isGitkeep(targetFilePath)) {
+        await removeGitkeep(dirname(targetFilePath), rootPath);
+    }
 
     console.log(`${chalk.gray("[UPDATED]:")} ${relativePath}`);
 

--- a/lib/utils/actions/utils.test.ts
+++ b/lib/utils/actions/utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { file, write } from "bun";
+import { removeGitkeep } from "./utils";
+
+describe("actions", () => {
+    describe("utils", () => {
+        test("should remove .gitkeep when present", async () => {
+            const rootPath = resolve(import.meta.dirname, ".test-generated");
+            const testDir = resolve(rootPath, "utils-test");
+            const gitkeepPath = resolve(testDir, ".gitkeep");
+
+            // Create directory and .gitkeep file
+            await write(gitkeepPath, "");
+
+            expect(await file(gitkeepPath).exists()).toBe(true);
+
+            await removeGitkeep(testDir, rootPath);
+
+            expect(await file(gitkeepPath).exists()).toBe(false);
+        });
+
+        test("should remove .gitkeep from all ancestor directories up to rootPath", async () => {
+            const rootPath = resolve(import.meta.dirname, ".test-generated");
+            const subdir = resolve(rootPath, "ancestor-test/subdir");
+            const gitkeepRoot = resolve(rootPath, "ancestor-test/.gitkeep");
+            const gitkeepSubdir = resolve(subdir, ".gitkeep");
+
+            // Create .gitkeep files in root and subdir
+            await write(gitkeepRoot, "");
+            await write(gitkeepSubdir, "");
+
+            expect(await file(gitkeepRoot).exists()).toBe(true);
+            expect(await file(gitkeepSubdir).exists()).toBe(true);
+
+            await removeGitkeep(subdir, rootPath);
+
+            // Both should be removed
+            expect(await file(gitkeepRoot).exists()).toBe(false);
+            expect(await file(gitkeepSubdir).exists()).toBe(false);
+        });
+    });
+});

--- a/lib/utils/actions/utils.test.ts
+++ b/lib/utils/actions/utils.test.ts
@@ -39,5 +39,21 @@ describe("actions", () => {
             expect(await file(gitkeepRoot).exists()).toBe(false);
             expect(await file(gitkeepSubdir).exists()).toBe(false);
         });
+
+        test("should not throw when removing .gitkeep concurrently", async () => {
+            const rootPath = resolve(import.meta.dirname, ".test-generated");
+            const concurrentDir = resolve(rootPath, "concurrent-test");
+            const gitkeepPath = resolve(concurrentDir, ".gitkeep");
+
+            await write(gitkeepPath, "");
+            expect(await file(gitkeepPath).exists()).toBe(true);
+
+            await Promise.all([
+                removeGitkeep(concurrentDir, rootPath),
+                removeGitkeep(concurrentDir, rootPath),
+            ]);
+
+            expect(await file(gitkeepPath).exists()).toBe(false);
+        });
     });
 });

--- a/lib/utils/actions/utils.ts
+++ b/lib/utils/actions/utils.ts
@@ -1,4 +1,4 @@
-import { resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { file } from "bun";
 
 export const skipUnlessViewType =
@@ -20,3 +20,17 @@ export const whenFileExists = async (
 
     return foundFile.size > 0;
 };
+
+export async function removeGitkeep(
+    targetDir: string,
+    rootPath: string,
+): Promise<void> {
+    let currentDir = targetDir;
+    while (currentDir !== rootPath && currentDir.startsWith(rootPath)) {
+        const gitkeepFile = file(join(currentDir, ".gitkeep"));
+        if (await gitkeepFile.exists()) {
+            await gitkeepFile.unlink();
+        }
+        currentDir = dirname(currentDir);
+    }
+}

--- a/lib/utils/actions/utils.ts
+++ b/lib/utils/actions/utils.ts
@@ -1,4 +1,4 @@
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { file } from "bun";
 
 export const skipUnlessViewType =
@@ -25,11 +25,23 @@ export async function removeGitkeep(
     targetDir: string,
     rootPath: string,
 ): Promise<void> {
-    let currentDir = targetDir;
-    while (currentDir !== rootPath && currentDir.startsWith(rootPath)) {
+    const normalizedRoot = resolve(rootPath);
+    let currentDir = resolve(targetDir);
+    while (
+        currentDir !== normalizedRoot &&
+        currentDir.startsWith(normalizedRoot + sep)
+    ) {
         const gitkeepFile = file(join(currentDir, ".gitkeep"));
-        if (await gitkeepFile.exists()) {
+        try {
             await gitkeepFile.unlink();
+        } catch (error) {
+            if (
+                !(error instanceof Error) ||
+                !("code" in error) ||
+                (error as NodeJS.ErrnoException).code !== "ENOENT"
+            ) {
+                throw error;
+            }
         }
         currentDir = dirname(currentDir);
     }

--- a/lib/utils/actions/utils.ts
+++ b/lib/utils/actions/utils.ts
@@ -1,4 +1,4 @@
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { file } from "bun";
 
 export const skipUnlessViewType =
@@ -33,4 +33,8 @@ export async function removeGitkeep(
         }
         currentDir = dirname(currentDir);
     }
+}
+
+export function isGitkeep(filePath: string): boolean {
+    return basename(filePath) === ".gitkeep";
 }


### PR DESCRIPTION
## Summary

Closes #102

When scaffolding creates a new file in a directory that previously only contained a `.gitkeep` placeholder, those `.gitkeep` files are now automatically removed — at **every ancestor directory level** up to `rootPath`, not just the immediate parent.

## Problem

`.gitkeep` files are placed at multiple levels in the generated workspace:
- `architecture/containers/.gitkeep` — root level (via `addMany templates/**/.gitkeep`)
- `architecture/containers/<system>/.gitkeep` — subfolder level (via workspace/system generators)

Previously, when a container file was written to `containers/<system>/my-container.dsl`, only `containers/<system>/.gitkeep` was removed. The root-level `containers/.gitkeep` remained, causing stale placeholder files in the output.

The same issue affected components and any other generator that writes into nested directories.

## Changes

### Core utility (`lib/utils/actions/utils.ts`)
- Added `removeGitkeep(targetDir, rootPath)` — walks **all ancestor directories** from `targetDir` up to (but not including) `rootPath`, removing `.gitkeep` at each level using Bun-native `file().exists()` + `file().unlink()`

### `add` action (`lib/utils/actions/add.ts`)
- Calls `removeGitkeep(dirname(targetFilePath), rootPath)` after writing each file

### `append` action (`lib/utils/actions/append.ts`)
- Calls `removeGitkeep(dirname(targetFilePath), rootPath)` on both write paths (`createIfNotExists` branch and main append path)

### `addMany` action
- No changes needed — delegates to `add()` internally, inheriting the fix automatically

## Tests

- `lib/utils/actions/utils.test.ts` *(new)* — 2 tests: single-level removal + ancestor-walk removal
- `lib/utils/actions/add.test.ts` — new tests for single-level and grandparent `.gitkeep` removal
- `lib/utils/actions/add-many.test.ts` — updated "shared templates" test (`.gitkeep` expected gone after `addMany`); new concurrent removal test
- `lib/utils/actions/append.test.ts` — new test asserting `.gitkeep` removed after `append()`

All 84 tests pass.

## Non-Interactive Verification

```bash
# Create a workspace and add a container — both levels of .gitkeep should be gone
scfz --dest /tmp/test-ws --workspaceName "Test" ...
scfz container --systemName "my-system" --elementName "my-container" ...
# architecture/containers/.gitkeep → removed
# architecture/containers/my-system/.gitkeep → removed
```