### PR TITLE
feat(update): check for latest version and show update instructions

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -41,8 +41,6 @@ Create a Structurizr DSL scaffolding in seconds!
     `),
     );
 
-    const updateMessage = await checkUpdate(pkg.version);
-
     const destPath = resolve(process.cwd(), args.dest);
     const workspacePath = getWorkspacePath(destPath);
 
@@ -77,6 +75,7 @@ Let's create a new one by answering the questions below.
             await exportWorkspace(
                 relative(process.cwd(), destPath) || process.cwd(),
             );
+            const updateMessage = await checkUpdate(pkg.version);
             if (updateMessage) console.log(updateMessage);
             process.exit(0);
         } catch (err) {
@@ -158,6 +157,7 @@ Let's create a new one by answering the questions below.
 
             await createGenerator(directGenerator);
             await exportWorkspace(relative(process.cwd(), workspacePath));
+            const updateMessage = await checkUpdate(pkg.version);
             if (updateMessage) console.log(updateMessage);
             process.exit(0);
         }
@@ -192,6 +192,7 @@ Let's create a new one by answering the questions below.
 
         await createGenerator(generator);
         await exportWorkspace(relative(process.cwd(), workspacePath));
+        const updateMessage = await checkUpdate(pkg.version);
         if (updateMessage) console.log(updateMessage);
         process.exit(0);
     } catch (err) {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -20,6 +20,7 @@ import {
     labelElementByName,
     SORTED_GENERATOR_AVAILABLE_ELEMENTS,
 } from "./utils/labels";
+import { checkUpdate } from "./utils/update";
 import { getWorkspaceJson, getWorkspacePath } from "./utils/workspace";
 
 type CLIArguments = {
@@ -39,6 +40,8 @@ Welcome to ${chalk.cyan(capitalCase(pkg.name.replace(/@[a-z-]*\//, "")))}
 Create a Structurizr DSL scaffolding in seconds!
     `),
     );
+
+    const updateMessage = await checkUpdate(pkg.version);
 
     const destPath = resolve(process.cwd(), args.dest);
     const workspacePath = getWorkspacePath(destPath);
@@ -74,6 +77,7 @@ Let's create a new one by answering the questions below.
             await exportWorkspace(
                 relative(process.cwd(), destPath) || process.cwd(),
             );
+            if (updateMessage) console.log(updateMessage);
             process.exit(0);
         } catch (err) {
             if ((err as ExitPromptError).name === "ExitPromptError") {
@@ -154,6 +158,7 @@ Let's create a new one by answering the questions below.
 
             await createGenerator(directGenerator);
             await exportWorkspace(relative(process.cwd(), workspacePath));
+            if (updateMessage) console.log(updateMessage);
             process.exit(0);
         }
 
@@ -187,6 +192,7 @@ Let's create a new one by answering the questions below.
 
         await createGenerator(generator);
         await exportWorkspace(relative(process.cwd(), workspacePath));
+        if (updateMessage) console.log(updateMessage);
         process.exit(0);
     } catch (err) {
         if ((err as ExitPromptError).name === "ExitPromptError") {

--- a/lib/utils/update.test.ts
+++ b/lib/utils/update.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkUpdate } from "./update";
+
+const UPDATE_CACHE_FILE = ".scaffoldizr-update.json";
+const UPDATE_CHECK_WINDOW = 86_400_000;
+
+let temporaryHomeDirectory = "";
+let originalHomeEnvironmentVariable: string | undefined;
+let originalNoUpdateCheckEnvironmentVariable: string | undefined;
+let originalStdoutIsTTY: boolean | undefined;
+
+function setStdoutTTY(isTTY: boolean) {
+    Object.defineProperty(process.stdout, "isTTY", {
+        value: isTTY,
+        configurable: true,
+    });
+}
+
+async function writeUpdateCacheFile(
+    latestVersion: string,
+    checkedAt: number = Date.now(),
+) {
+    const updateCachePath = join(temporaryHomeDirectory, UPDATE_CACHE_FILE);
+    await writeFile(
+        updateCachePath,
+        JSON.stringify({ latestVersion, checkedAt }),
+        "utf8",
+    );
+}
+
+describe("checkUpdate", () => {
+    beforeEach(async () => {
+        temporaryHomeDirectory = await mkdtemp(
+            join(tmpdir(), "scaffoldizr-update-test-"),
+        );
+        originalHomeEnvironmentVariable = process.env.HOME;
+        originalNoUpdateCheckEnvironmentVariable =
+            process.env.SCFZ_NO_UPDATE_CHECK;
+        originalStdoutIsTTY = process.stdout.isTTY;
+
+        process.env.HOME = temporaryHomeDirectory;
+        delete process.env.SCFZ_NO_UPDATE_CHECK;
+        setStdoutTTY(true);
+    });
+
+    afterEach(async () => {
+        if (originalHomeEnvironmentVariable === undefined) {
+            delete process.env.HOME;
+        } else {
+            process.env.HOME = originalHomeEnvironmentVariable;
+        }
+
+        if (originalNoUpdateCheckEnvironmentVariable === undefined) {
+            delete process.env.SCFZ_NO_UPDATE_CHECK;
+        } else {
+            process.env.SCFZ_NO_UPDATE_CHECK =
+                originalNoUpdateCheckEnvironmentVariable;
+        }
+
+        setStdoutTTY(Boolean(originalStdoutIsTTY));
+        await rm(temporaryHomeDirectory, { recursive: true, force: true });
+    });
+
+    describe("version comparison via fresh cache", () => {
+        it("returns notification when 0.10.0 is newer than 0.9.3", async () => {
+            await writeUpdateCacheFile("0.10.0");
+
+            const updateMessage = await checkUpdate("0.9.3");
+
+            expect(updateMessage).toBeString();
+            expect(updateMessage).toContain(
+                "curl -s https://formulamonks.github.io/",
+            );
+        });
+
+        it("returns null when 0.9.3 equals 0.9.3", async () => {
+            await writeUpdateCacheFile("0.9.3");
+
+            const updateMessage = await checkUpdate("0.9.3");
+
+            expect(updateMessage).toBeNull();
+        });
+
+        it("returns notification when 1.0.0 is newer than 0.9.3", async () => {
+            await writeUpdateCacheFile("1.0.0");
+
+            const updateMessage = await checkUpdate("0.9.3");
+
+            expect(updateMessage).toBeString();
+            expect(updateMessage).toContain(
+                "curl -s https://formulamonks.github.io/",
+            );
+        });
+
+        it("returns null when 0.9.3 is not newer than 1.0.0", async () => {
+            await writeUpdateCacheFile("0.9.3");
+
+            const updateMessage = await checkUpdate("1.0.0");
+
+            expect(updateMessage).toBeNull();
+        });
+    });
+
+    describe("bailout guards", () => {
+        it("returns null when stdout is not a TTY", async () => {
+            setStdoutTTY(false);
+
+            const updateMessage = await checkUpdate("0.9.3");
+
+            expect(updateMessage).toBeNull();
+        });
+
+        it("returns null when SCFZ_NO_UPDATE_CHECK is set", async () => {
+            process.env.SCFZ_NO_UPDATE_CHECK = "1";
+
+            const updateMessage = await checkUpdate("0.9.3");
+
+            expect(updateMessage).toBeNull();
+        });
+
+        it("returns null when HOME is missing", async () => {
+            delete process.env.HOME;
+
+            const updateMessage = await checkUpdate("0.9.3");
+
+            expect(updateMessage).toBeNull();
+        });
+    });
+
+    describe("cache handling", () => {
+        it("returns notification string for fresh cache with newer version", async () => {
+            await writeUpdateCacheFile("2.0.0");
+
+            const updateMessage = await checkUpdate("1.9.9");
+
+            expect(updateMessage).toBeString();
+            expect(updateMessage).toContain(
+                "curl -s https://formulamonks.github.io/",
+            );
+        });
+
+        it("returns null for fresh cache with same or older version", async () => {
+            await writeUpdateCacheFile("1.0.0");
+            const sameVersionUpdateMessage = await checkUpdate("1.0.0");
+            expect(sameVersionUpdateMessage).toBeNull();
+
+            await writeUpdateCacheFile("0.9.9");
+            const olderVersionUpdateMessage = await checkUpdate("1.0.0");
+            expect(olderVersionUpdateMessage).toBeNull();
+        });
+
+        it("returns null for stale cache", async () => {
+            await writeUpdateCacheFile(
+                "2.0.0",
+                Date.now() - UPDATE_CHECK_WINDOW - 3_600_000,
+            );
+
+            const updateMessage = await checkUpdate("1.0.0");
+
+            expect(updateMessage).toBeNull();
+        });
+
+        it("returns null for missing cache", async () => {
+            const updateMessage = await checkUpdate("0.9.3");
+
+            expect(updateMessage).toBeNull();
+        });
+
+        it("returns null for malformed cache", async () => {
+            const updateCachePath = join(
+                temporaryHomeDirectory,
+                UPDATE_CACHE_FILE,
+            );
+            await writeFile(updateCachePath, "{ malformed", "utf8");
+
+            const updateMessage = await checkUpdate("0.9.3");
+
+            expect(updateMessage).toBeNull();
+        });
+    });
+});

--- a/lib/utils/update.test.ts
+++ b/lib/utils/update.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import * as operatingSystem from "node:os";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { checkUpdate } from "./update";
@@ -11,6 +12,8 @@ let temporaryHomeDirectory = "";
 let originalHomeEnvironmentVariable: string | undefined;
 let originalNoUpdateCheckEnvironmentVariable: string | undefined;
 let originalStdoutIsTTY: boolean | undefined;
+let originalFetch: typeof globalThis.fetch;
+let homedirSpy: ReturnType<typeof spyOn>;
 
 function setStdoutTTY(isTTY: boolean) {
     Object.defineProperty(process.stdout, "isTTY", {
@@ -40,10 +43,18 @@ describe("checkUpdate", () => {
         originalNoUpdateCheckEnvironmentVariable =
             process.env.SCFZ_NO_UPDATE_CHECK;
         originalStdoutIsTTY = process.stdout.isTTY;
+        originalFetch = globalThis.fetch;
+        homedirSpy = spyOn(operatingSystem, "homedir").mockReturnValue(
+            temporaryHomeDirectory,
+        );
 
         process.env.HOME = temporaryHomeDirectory;
         delete process.env.SCFZ_NO_UPDATE_CHECK;
         setStdoutTTY(true);
+        globalThis.fetch = ((..._args: Parameters<typeof globalThis.fetch>) =>
+            Promise.resolve(
+                new Response(null, { status: 500 }),
+            )) as unknown as typeof globalThis.fetch;
     });
 
     afterEach(async () => {
@@ -61,6 +72,8 @@ describe("checkUpdate", () => {
         }
 
         setStdoutTTY(Boolean(originalStdoutIsTTY));
+        globalThis.fetch = originalFetch;
+        homedirSpy.mockRestore();
         await rm(temporaryHomeDirectory, { recursive: true, force: true });
     });
 
@@ -121,8 +134,8 @@ describe("checkUpdate", () => {
             expect(updateMessage).toBeNull();
         });
 
-        it("returns null when HOME is missing", async () => {
-            delete process.env.HOME;
+        it("returns null when SCFZ_NO_UPDATE_CHECK is set to empty string", async () => {
+            process.env.SCFZ_NO_UPDATE_CHECK = "";
 
             const updateMessage = await checkUpdate("0.9.3");
 

--- a/lib/utils/update.ts
+++ b/lib/utils/update.ts
@@ -1,5 +1,6 @@
-import { promises as filesystem } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
+import { file, write } from "bun";
 import chalk from "chalk";
 
 type UpdateCache = {
@@ -28,6 +29,14 @@ function isNewerVersion(
 ): boolean {
     const latestSegments = versionToSegments(latestVersion);
     const currentSegments = versionToSegments(currentVersion);
+
+    if (
+        latestSegments.some(Number.isNaN) ||
+        currentSegments.some(Number.isNaN)
+    ) {
+        return false;
+    }
+
     const maxSegmentsLength = Math.max(
         latestSegments.length,
         currentSegments.length,
@@ -40,34 +49,51 @@ function isNewerVersion(
     ) {
         const latestSegment = latestSegments[segmentIndex] ?? 0;
         const currentSegment = currentSegments[segmentIndex] ?? 0;
-
-        if (latestSegment > currentSegment) {
-            return true;
-        }
-
-        if (latestSegment < currentSegment) {
-            return false;
-        }
+        if (latestSegment !== currentSegment)
+            return latestSegment > currentSegment;
     }
 
     return false;
+}
+
+function buildBannerLine(content: string, innerWidth: number): string {
+    return (
+        chalk.yellow("│  ") + content.padEnd(innerWidth) + chalk.yellow("  │")
+    );
 }
 
 function buildUpdateNotification(
     currentVersion: string,
     latestVersion: string,
 ): string {
-    const versionLine = `│  Update available: ${currentVersion} → ${latestVersion}        │`;
+    const versionText = `Update available: ${currentVersion} → ${latestVersion}`;
+    const curlLine1 = "curl -s https://formulamonks.github.io/";
+    const curlLine2 = "scaffoldizr/assets/install.sh | sh";
+    const runToUpdateText = "Run to update:";
+
+    const innerWidth = Math.max(
+        versionText.length,
+        curlLine1.length,
+        curlLine2.length,
+        runToUpdateText.length,
+    );
+    const horizontalBorder = "─".repeat(innerWidth + 4);
 
     return [
         "",
-        chalk.yellow("╭──────────────────────────────────────────────────╮"),
-        chalk.bold(versionLine),
-        chalk.yellow("│                                                  │"),
-        chalk.yellow("│  Run to update:                                  │"),
-        `${chalk.yellow("│  ")}${chalk.cyan("curl -s https://formulamonks.github.io/")}${chalk.yellow("         │")}`,
-        `${chalk.yellow("│  ")}${chalk.cyan("scaffoldizr/assets/install.sh | sh")}${chalk.yellow("              │")}`,
-        chalk.yellow("╰──────────────────────────────────────────────────╯"),
+        chalk.yellow(`╭${horizontalBorder}╮`),
+        chalk.yellow("│  ") +
+            chalk.bold(versionText.padEnd(innerWidth)) +
+            chalk.yellow("  │"),
+        buildBannerLine("", innerWidth),
+        buildBannerLine(runToUpdateText, innerWidth),
+        chalk.yellow("│  ") +
+            chalk.cyan(curlLine1.padEnd(innerWidth)) +
+            chalk.yellow("  │"),
+        chalk.yellow("│  ") +
+            chalk.cyan(curlLine2.padEnd(innerWidth)) +
+            chalk.yellow("  │"),
+        chalk.yellow(`╰${horizontalBorder}╯`),
     ].join("\n");
 }
 
@@ -75,7 +101,7 @@ async function readUpdateCache(
     cacheFilePath: string,
 ): Promise<UpdateCache | null> {
     try {
-        const cacheContent = await filesystem.readFile(cacheFilePath, "utf8");
+        const cacheContent = await file(cacheFilePath).text();
         const parsedCache = JSON.parse(cacheContent) as Partial<UpdateCache>;
 
         if (
@@ -99,6 +125,7 @@ async function refreshUpdateCache(cacheFilePath: string): Promise<void> {
         const latestReleaseResponse = await fetch(LATEST_RELEASE_URL, {
             headers: {
                 Accept: "application/vnd.github+json",
+                "User-Agent": "scaffoldizr-cli",
                 "X-GitHub-Api-Version": "2022-11-28",
             },
             signal: AbortSignal.timeout(2000),
@@ -121,11 +148,7 @@ async function refreshUpdateCache(cacheFilePath: string): Promise<void> {
             checkedAt: Date.now(),
         };
 
-        await filesystem.writeFile(
-            cacheFilePath,
-            JSON.stringify(cachePayload),
-            "utf8",
-        );
+        await write(cacheFilePath, JSON.stringify(cachePayload));
     } catch {}
 }
 
@@ -136,15 +159,11 @@ export async function checkUpdate(
         return null;
     }
 
-    if (process.env.SCFZ_NO_UPDATE_CHECK) {
+    if (process.env.SCFZ_NO_UPDATE_CHECK !== undefined) {
         return null;
     }
 
-    if (!process.env.HOME) {
-        return null;
-    }
-
-    const cacheFilePath = join(process.env.HOME, UPDATE_CACHE_FILE);
+    const cacheFilePath = join(homedir(), UPDATE_CACHE_FILE);
     const cachedUpdate = await readUpdateCache(cacheFilePath);
 
     if (cachedUpdate) {

--- a/lib/utils/update.ts
+++ b/lib/utils/update.ts
@@ -1,0 +1,178 @@
+import { promises as filesystem } from "node:fs";
+import { join } from "node:path";
+import chalk from "chalk";
+
+type UpdateCache = {
+    latestVersion: string;
+    checkedAt: number;
+};
+
+const UPDATE_CACHE_FILE = ".scaffoldizr-update.json";
+const UPDATE_CHECK_WINDOW = 86_400_000;
+const LATEST_RELEASE_URL =
+    "https://api.github.com/repos/FormulaMonks/scaffoldizr/releases/latest";
+
+function stripVersionPrefix(version: string): string {
+    return version.replace(/^v/, "");
+}
+
+function versionToSegments(version: string): number[] {
+    return stripVersionPrefix(version)
+        .split(".")
+        .map((versionSegment) => Number(versionSegment));
+}
+
+function isNewerVersion(
+    latestVersion: string,
+    currentVersion: string,
+): boolean {
+    const latestSegments = versionToSegments(latestVersion);
+    const currentSegments = versionToSegments(currentVersion);
+    const maxSegmentsLength = Math.max(
+        latestSegments.length,
+        currentSegments.length,
+    );
+
+    for (
+        let segmentIndex = 0;
+        segmentIndex < maxSegmentsLength;
+        segmentIndex++
+    ) {
+        const latestSegment = latestSegments[segmentIndex] ?? 0;
+        const currentSegment = currentSegments[segmentIndex] ?? 0;
+
+        if (latestSegment > currentSegment) {
+            return true;
+        }
+
+        if (latestSegment < currentSegment) {
+            return false;
+        }
+    }
+
+    return false;
+}
+
+function buildUpdateNotification(
+    currentVersion: string,
+    latestVersion: string,
+): string {
+    const versionLine = `│  Update available: ${currentVersion} → ${latestVersion}        │`;
+
+    return [
+        "",
+        chalk.yellow("╭──────────────────────────────────────────────────╮"),
+        chalk.bold(versionLine),
+        chalk.yellow("│                                                  │"),
+        chalk.yellow("│  Run to update:                                  │"),
+        `${chalk.yellow("│  ")}${chalk.cyan("curl -s https://formulamonks.github.io/")}${chalk.yellow("         │")}`,
+        `${chalk.yellow("│  ")}${chalk.cyan("scaffoldizr/assets/install.sh | sh")}${chalk.yellow("              │")}`,
+        chalk.yellow("╰──────────────────────────────────────────────────╯"),
+    ].join("\n");
+}
+
+async function readUpdateCache(
+    cacheFilePath: string,
+): Promise<UpdateCache | null> {
+    try {
+        const cacheContent = await filesystem.readFile(cacheFilePath, "utf8");
+        const parsedCache = JSON.parse(cacheContent) as Partial<UpdateCache>;
+
+        if (
+            typeof parsedCache.latestVersion !== "string" ||
+            typeof parsedCache.checkedAt !== "number"
+        ) {
+            return null;
+        }
+
+        return {
+            latestVersion: parsedCache.latestVersion,
+            checkedAt: parsedCache.checkedAt,
+        };
+    } catch {
+        return null;
+    }
+}
+
+async function refreshUpdateCache(cacheFilePath: string): Promise<void> {
+    try {
+        const latestReleaseResponse = await fetch(LATEST_RELEASE_URL, {
+            headers: {
+                Accept: "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            signal: AbortSignal.timeout(2000),
+        });
+
+        if (!latestReleaseResponse.ok) {
+            return;
+        }
+
+        const releasePayload = (await latestReleaseResponse.json()) as {
+            tag_name?: unknown;
+        };
+
+        if (typeof releasePayload.tag_name !== "string") {
+            return;
+        }
+
+        const cachePayload: UpdateCache = {
+            latestVersion: stripVersionPrefix(releasePayload.tag_name),
+            checkedAt: Date.now(),
+        };
+
+        await filesystem.writeFile(
+            cacheFilePath,
+            JSON.stringify(cachePayload),
+            "utf8",
+        );
+    } catch {}
+}
+
+export async function checkUpdate(
+    currentVersion: string,
+): Promise<string | null> {
+    if (!process.stdout.isTTY) {
+        return null;
+    }
+
+    if (process.env.SCFZ_NO_UPDATE_CHECK) {
+        return null;
+    }
+
+    if (!process.env.HOME) {
+        return null;
+    }
+
+    const cacheFilePath = join(process.env.HOME, UPDATE_CACHE_FILE);
+    const cachedUpdate = await readUpdateCache(cacheFilePath);
+
+    if (cachedUpdate) {
+        const cacheIsFresh =
+            Date.now() - cachedUpdate.checkedAt < UPDATE_CHECK_WINDOW;
+
+        if (cacheIsFresh) {
+            const normalizedCurrentVersion = stripVersionPrefix(currentVersion);
+            const normalizedLatestVersion = stripVersionPrefix(
+                cachedUpdate.latestVersion,
+            );
+
+            if (
+                isNewerVersion(
+                    normalizedLatestVersion,
+                    normalizedCurrentVersion,
+                )
+            ) {
+                return buildUpdateNotification(
+                    normalizedCurrentVersion,
+                    normalizedLatestVersion,
+                );
+            }
+
+            return null;
+        }
+    }
+
+    void refreshUpdateCache(cacheFilePath);
+    return null;
+}


### PR DESCRIPTION
## Summary
Add update notification feature that checks for latest version and shows update instructions.

Closes #3

## Changes Made
- `lib/utils/update.ts` — new module: `checkUpdate(currentVersion)` checks GitHub Releases API with 24h local cache, TTY guard, env guard, numeric semver comparison
- `lib/main.ts` — imports and calls `checkUpdate`; prints update notification after generator completes (before exit), not during tool output
- `lib/utils/update.test.ts` — 12 unit tests covering version comparison, cache hits/misses/stale, and bailout guards

## Testing Notes
- All unit tests pass (97 tests total)
- Build and lint checks passed
- Pre-commit hooks executed successfully