### PR TITLE
feat: migrate to unified structurizr/structurizr Docker image

### DIFF
--- a/.claude/skills/scaffoldizr/elements/component.md
+++ b/.claude/skills/scaffoldizr/elements/component.md
@@ -17,7 +17,7 @@ _⚠️ IMPORTANT:_ Components can only be created when the [Workspace Scope](..
 
 1. Verify if a Component archetype has been created that fits the user's needs. If so, reference that archetype to create the Component.
 
-2. Verify that the target container where the component will be created already exists. If not, prompt the user to create that container first. Refer to [structurizr-cli list elements](../extra/CLI.md#list-elements-within-a-workspace) to check existing elements.
+2. Verify that the target container where the component will be created already exists. If not, prompt the user to create that container first. Refer to [Structurizr list elements](../extra/CLI.md#list-elements-within-a-workspace) to check existing elements.
 
 3. Create a new entry under `./architecture/components/{system-name}/{container-name}.dsl`. Create the file if it does not exist. The file name should follow this name format:
 
@@ -45,7 +45,7 @@ _⚠️ IMPORTANT:_ Components can only be created when the [Workspace Scope](..
 
 5. Create relationships between the component and other elements (people, systems, containers, components, etc.) as needed. Follow instructions on [relationships](./relationship.md) documentation for further details on how to create relationships.
 
-6. Validate the workspace to ensure the component has been created successfully and there are no errors. Refer to [structurizr-cli validate](../extra/CLI.md#validation-and-error-troubleshooting) for further details.
+6. Validate the workspace to ensure the component has been created successfully and there are no errors. Refer to [Structurizr validate](../extra/CLI.md#validation-and-error-troubleshooting) for further details.
 
 ## Using Scaffoldizr CLI (preferred for AI agents)
 

--- a/.claude/skills/scaffoldizr/elements/container.md
+++ b/.claude/skills/scaffoldizr/elements/container.md
@@ -14,7 +14,7 @@ _⚠️ IMPORTANT:_ Containers can only be created when the [Workspace Scope](..
 
 1. Verify if a Container archetype has been created that fits the user's needs. If so, reference that archetype to create the Container.
 
-2. Verify that the target software system where the container will be created already exists. If not, prompt the user to create that software system first. Refer to [structurizr-cli list elements](../extra/CLI.md#list-elements-within-a-workspace) to check existing elements.
+2. Verify that the target software system where the container will be created already exists. If not, prompt the user to create that software system first. Refer to [Structurizr list elements](../extra/CLI.md#list-elements-within-a-workspace) to check existing elements.
 
 3. Create a new file under `./architecture/containers/{system-name}/{container-name}.dsl` that follows this name format:
 
@@ -41,7 +41,7 @@ _⚠️ IMPORTANT:_ Containers can only be created when the [Workspace Scope](..
 
 5. Create relationships between the container and other elements (people, systems, containers, components, etc.) as needed. Follow instructions on [relationships](./relationship.md) documentation for further details on how to create relationships.
 
-6. Validate the workspace to ensure the container has been created successfully and there are no errors. Refer to [structurizr-cli validate](../extra/CLI.md#validation-and-error-troubleshooting) for further details.
+6. Validate the workspace to ensure the container has been created successfully and there are no errors. Refer to [Structurizr validate](../extra/CLI.md#validation-and-error-troubleshooting) for further details.
 
 ## Using Scaffoldizr CLI (preferred for AI agents)
 

--- a/.claude/skills/scaffoldizr/elements/person.md
+++ b/.claude/skills/scaffoldizr/elements/person.md
@@ -6,7 +6,7 @@ In the C4 model, a person represents a user or actor that interacts with the sof
 
 ## Create a Person
 
-1. Verify that the person does not already exist in the `./architecture/systems/_people.dsl` file.  Refer to [structurizr-cli list elements](../extra/CLI.md#list-elements-within-a-workspace).
+1. Verify that the person does not already exist in the `./architecture/systems/_people.dsl` file.  Refer to [Structurizr list elements](../extra/CLI.md#list-elements-within-a-workspace).
 
 2. Create a new entry under `./architecture/systems/_people.dsl`. Create the file if it does not exist.
 
@@ -27,7 +27,7 @@ In the C4 model, a person represents a user or actor that interacts with the sof
 
 4. Create relationships between the person and other elements (software systems, containers, etc.) as needed. Follow instructions on [relationships](./relationship.md) documentation for further details on how to create relationships.
 
-5. Validate the workspace to ensure the person has been created successfully and there are no errors. Refer to [structurizr-cli validate](../extra/CLI.md#validation-and-error-troubleshooting) for further details.
+5. Validate the workspace to ensure the person has been created successfully and there are no errors. Refer to [Structurizr validate](../extra/CLI.md#validation-and-error-troubleshooting) for further details.
 
 ## Using Scaffoldizr CLI (preferred for AI agents)
 

--- a/.claude/skills/scaffoldizr/elements/relationship.md
+++ b/.claude/skills/scaffoldizr/elements/relationship.md
@@ -12,7 +12,7 @@ Relationship archetypes can be defined, as long as the archetype exists. Check [
 
 1. Verify if a Relationship archetype has been created that fits the user's needs. If so, reference that archetype to create the relationship.
 
-2. Verify that the elements that will be part of the relationship (source and target) already exist. If not, prompt the user to create those elements first. Refer to [structurizr-cli list elements](../extra/CLI.md#list-elements-within-a-workspace) to check existing elements.
+2. Verify that the elements that will be part of the relationship (source and target) already exist. If not, prompt the user to create those elements first. Refer to [Structurizr list elements](../extra/CLI.md#list-elements-within-a-workspace) to check existing elements.
 
 3. The relationship should be created within the file of the source element (person, software system, or external software system) that initiates the relationship. Create the file if it does not exist. The options are as follows:
 
@@ -32,7 +32,7 @@ Relationship archetypes can be defined, as long as the archetype exists. Check [
       - `{targetElement}` is the name of the target element (person, software system, container, or component) in pascal case (e.g. `TargetElement`).
       - `{description}` denotes the relationship between the elements. E.g. "Uses", "Sends data to", "Reads from", etc. This description is optional when using relationship archetypes that already define it.
 
-5. Validate the workspace to ensure the relationship has been created successfully and there are no errors. Refer to [structurizr-cli validate](../extra/CLI.md#validation-and-error-troubleshooting) for further details.
+5. Validate the workspace to ensure the relationship has been created successfully and there are no errors. Refer to [Structurizr validate](../extra/CLI.md#validation-and-error-troubleshooting) for further details.
 
 ## References
 

--- a/.claude/skills/scaffoldizr/elements/softwareSystem.md
+++ b/.claude/skills/scaffoldizr/elements/softwareSystem.md
@@ -40,7 +40,7 @@ _⚠️ IMPORTANT:_ Software Systems can only be created when the [Workspace Sco
 
 4. Create relationships between the software system and other elements (people, systems, containers, etc.) as needed. Follow instructions on [relationships](./relationship.md) documentation for further details on how to create relationships.
 
-5. Validate the workspace to ensure the software system has been created successfully and there are no errors. Refer to [structurizr-cli validate](../extra/CLI.md#validation-and-error-troubleshooting) for further details.
+5. Validate the workspace to ensure the software system has been created successfully and there are no errors. Refer to [Structurizr validate](../extra/CLI.md#validation-and-error-troubleshooting) for further details.
 
 ## Using Scaffoldizr CLI (preferred for AI agents)
 

--- a/.claude/skills/scaffoldizr/extra/CLI.md
+++ b/.claude/skills/scaffoldizr/extra/CLI.md
@@ -1,14 +1,14 @@
 # Structurizr CLI
 
-There are various ways to gather information, validate and troubleshoot errors in the Structurizr workspace. All of them rely on the `structurizr-cli` tool.
-If `structurizr-cli` is not installed, follow [the instructions](https://docs.structurizr.com/cli/installation) to install it, or prompt the user to install it.
+There are various ways to gather information, validate and troubleshoot errors in the Structurizr workspace. All of them use the unified `structurizr/structurizr` Docker image.
+Refer to the [Structurizr commands reference](https://docs.structurizr.com/commands) for the full list of available commands.
 
 ## List elements within a workspace
 
-You can list all the elements within a Structurizr workspace by running the following command in the `./architecture` folder:
+You can list all the elements within a Structurizr workspace by running the following command from the workspace root (the folder containing `workspace.dsl`):
 
 ```bash
-structurizr-cli list -workspace {workspace-path}/architecture/workspace.dsl
+docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr list -w /usr/local/structurizr/workspace.dsl
 ```
 
 The command will output the current elements in the following format:
@@ -22,16 +22,16 @@ The command will output the current elements in the following format:
 
 ## Validation and Error Troubleshooting
 
-Whenever changes are made to the DSL files, it's important to validate that the workspace is still valid and there are no errors. To do so, run the following command in the `./architecture` folder:
+Whenever changes are made to the DSL files, it's important to validate that the workspace is still valid and there are no errors. To do so, run the following command:
 
 ```bash
-structurizr-cli validate -workspace {workspace-path}/architecture/workspace.dsl
+docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr validate -w /usr/local/structurizr/workspace.dsl
 ```
 
 ### Inspect violations
 
-The inspect command allows you to inspect a JSON/DSL workspace via the workspace inspection feature. The return code indicates the number of violations that were shown. To run the inspect command, use the following command in the `./architecture` folder:
+The inspect command allows you to inspect a JSON/DSL workspace via the workspace inspection feature. The return code indicates the number of violations that were shown. To run the inspect command:
 
 ```bash
-structurizr-cli inspect -workspace {workspace-path}/architecture/workspace.dsl
+docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr inspect -w /usr/local/structurizr/workspace.dsl
 ```

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -83,7 +83,7 @@ jobs:
         if: ${{ matrix.os == 'macos' }}
         run: |
           brew install docker colima
-          colima start --cpu 2 --memory 4
+          colima start --cpu 2 --memory 4 --vm-type qemu
           docker info
       - name: Pull Structurizr Docker image
         if: ${{ matrix.os != 'windows' }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Start Docker (macOS)
         if: ${{ matrix.os == 'macos' }}
         run: |
-          brew install docker colima
+          brew install docker colima qemu
           colima start --cpu 2 --memory 4 --vm-type qemu
           docker info
       - name: Pull Structurizr Docker image

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,8 +13,6 @@ jobs:
   e2e:
     name: e2e-${{matrix.name}}
     runs-on: ${{matrix.runs-on}}
-    env:
-      STRUCTURIZR_CLI_VERSION: v2025.11.09
     strategy:
       fail-fast: true
       matrix:
@@ -56,11 +54,6 @@ jobs:
           choco install jq --version 1.7.1
           choco install bun --version 1.3.3
         if: ${{ matrix.os == 'windows' }}
-      - uses: actions/setup-java@v5
-        if: ${{ matrix.os == 'windows' }}
-        with:
-          distribution: "temurin" # See 'Supported distributions' for available options
-          java-version: "21"
       - run: bun install --ignore-scripts
       - name: Download version to test
         uses: actions/download-artifact@v7
@@ -86,30 +79,15 @@ jobs:
           } catch {
             Write-Error "An error occurred: $_"
           }
-      - name: Cache Structurizr CLI
-        id: structurizr-cli-cache
-        uses: actions/cache@v5
-        with:
-          path: dist/structurizr-cli-bin
-          key: ${{ matrix.os }}-structurizr-cli-${{ env.STRUCTURIZR_CLI_VERSION }}
-      - name: Download Structurizr CLI
-        if: steps.structurizr-cli-cache.outputs.cache-hit != 'true' && matrix.os != 'windows'
+      - name: Start Docker (macOS)
+        if: ${{ matrix.os == 'macos' }}
         run: |
-          mkdir -p dist/structurizr-cli-bin
-          wget https://github.com/structurizr/cli/releases/download/${{ env.STRUCTURIZR_CLI_VERSION }}/structurizr-cli.zip
-          unzip ./structurizr-cli.zip -d dist/structurizr-cli-bin/
-          ls -la dist/structurizr-cli-bin/
-      - name: Download Structurizr CLI (Windows)
-        if: steps.structurizr-cli-cache.outputs.cache-hit != 'true' && matrix.os == 'windows'
-        run: |
-          try {
-            New-Item -ItemType Directory -Force -Path dist/structurizr-cli-bin
-            Invoke-WebRequest -Uri "https://github.com/structurizr/cli/releases/download/${{ env.STRUCTURIZR_CLI_VERSION }}/structurizr-cli.zip" -OutFile structurizr-cli.zip
-            Expand-Archive -Path structurizr-cli.zip -DestinationPath dist/structurizr-cli-bin/
-            Get-ChildItem -Path dist/structurizr-cli-bin/
-          } catch {
-            Write-Error "An error occurred: $_"
-          }
+          brew install docker colima
+          colima start --cpu 2 --memory 4
+          docker info
+      - name: Pull Structurizr Docker image
+        if: ${{ matrix.os != 'windows' }}
+        run: docker pull structurizr/structurizr
       - name: Extract version and add it to env variables
         if: ${{ matrix.os != 'windows' }}
         run: |
@@ -126,28 +104,22 @@ jobs:
       - name: E2E Test (Smoke)
         if: ${{ inputs.smoke && matrix.os != 'windows' }}
         run: |
-          export STRUCTURIZR_CLI_PATH=./dist/structurizr-cli-bin/structurizr.sh
           export TMP_FOLDER=${{ runner.temp }}
           bun test:e2e:smoke
       - name: E2E Test (Full)
         if: ${{ !inputs.smoke && matrix.os != 'windows' }}
         run: |
-          export STRUCTURIZR_CLI_PATH=./dist/structurizr-cli-bin/structurizr.sh
           export TMP_FOLDER=${{ runner.temp }}
           bun test:e2e
       - name: E2E Test (Smoke) (Windows)
         if: ${{ inputs.smoke && matrix.os == 'windows' }}
         run: |
-          $env:STRUCTURIZR_CLI_PATH = ".\dist\structurizr-cli-bin\structurizr.bat"
           $env:TMP_FOLDER = "${{ runner.temp }}"
           $env:INPUT_TIMEOUT = "600"
-          java -version
           bun test:e2e:smoke
       - name: E2E Test (Full) (Windows)
         if: ${{ !inputs.smoke && matrix.os == 'windows' }}
         run: |
-          $env:STRUCTURIZR_CLI_PATH = ".\dist\structurizr-cli-bin\structurizr.bat"
           $env:TMP_FOLDER = "${{ runner.temp }}"
           $env:INPUT_TIMEOUT = "600"
-          java -version
           bun test:e2e

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -79,14 +79,8 @@ jobs:
           } catch {
             Write-Error "An error occurred: $_"
           }
-      - name: Start Docker (macOS)
-        if: ${{ matrix.os == 'macos' }}
-        run: |
-          brew install docker colima qemu
-          colima start --cpu 2 --memory 4 --vm-type qemu
-          docker info
       - name: Pull Structurizr Docker image
-        if: ${{ matrix.os != 'windows' }}
+        if: ${{ matrix.os == 'ubuntu' }}
         run: docker pull structurizr/structurizr
       - name: Extract version and add it to env variables
         if: ${{ matrix.os != 'windows' }}
@@ -102,15 +96,21 @@ jobs:
             Write-Error "An error occurred: $_"
           }
       - name: E2E Test (Smoke)
-        if: ${{ inputs.smoke && matrix.os != 'windows' }}
+        if: ${{ inputs.smoke && matrix.os == 'ubuntu' }}
         run: |
           export TMP_FOLDER=${{ runner.temp }}
           bun test:e2e:smoke
       - name: E2E Test (Full)
-        if: ${{ !inputs.smoke && matrix.os != 'windows' }}
+        if: ${{ !inputs.smoke && matrix.os == 'ubuntu' }}
         run: |
           export TMP_FOLDER=${{ runner.temp }}
           bun test:e2e
+      - name: E2E Test (Smoke) (macOS)
+        if: ${{ matrix.os == 'macos' }}
+        run: |
+          export TMP_FOLDER=${{ runner.temp }}
+          export INPUT_TIMEOUT=600
+          bun test:e2e:smoke:windows
       - name: E2E Test (Smoke) (Windows)
         if: ${{ matrix.os == 'windows' }}
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -112,14 +112,8 @@ jobs:
           export TMP_FOLDER=${{ runner.temp }}
           bun test:e2e
       - name: E2E Test (Smoke) (Windows)
-        if: ${{ inputs.smoke && matrix.os == 'windows' }}
+        if: ${{ matrix.os == 'windows' }}
         run: |
           $env:TMP_FOLDER = "${{ runner.temp }}"
           $env:INPUT_TIMEOUT = "600"
-          bun test:e2e:smoke
-      - name: E2E Test (Full) (Windows)
-        if: ${{ !inputs.smoke && matrix.os == 'windows' }}
-        run: |
-          $env:TMP_FOLDER = "${{ runner.temp }}"
-          $env:INPUT_TIMEOUT = "600"
-          bun test:e2e
+          bun test:e2e:smoke:windows

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ where `{docs_folder}` is a folder where dsl files will be generated. The tool cr
 
 Scaffoldizr supports non-interactive execution by routing to specific subcommands and passing parameters as CLI flags. This mode is ideal for AI agents or automation scripts.
 
+### AI Agent Skill Installation
+
+Install the Scaffoldizr skill into your AI agent environment (e.g. OpenCode):
+
+```bash
+npx skills add formulamonks/scaffoldizr
+```
+
+This provides the agent with Scaffoldizr conventions, element creation rules, workspace scope constraints, and CLI usage patterns.
+
 ### Subcommand Routing
 
 When a workspace already exists, you can bypass the main menu by specifying a generator as a subcommand:

--- a/architecture/decisions/0003-unified-structurizr-docker.md
+++ b/architecture/decisions/0003-unified-structurizr-docker.md
@@ -1,0 +1,53 @@
+# 3. Migrate to Unified Structurizr Docker Image
+
+Date: 2026-04-10
+
+## Status
+
+Accepted
+
+## Context
+
+Scaffoldizr relied on two separate Structurizr tools:
+
+1. **`structurizr/lite`** Docker image — used by `run.sh` to serve the workspace locally for authoring and visualization.
+2. **`structurizr-cli`** standalone binary — used by `update.sh` to push the workspace to a remote Structurizr instance, and by the CLI's `--export` flag to compile `workspace.dsl` to `workspace.json`.
+
+In late 2025, Structurizr announced the consolidation of all its tools — Structurizr Lite, Structurizr CLI, and Structurizr on-premises — into a **single unified tool and Docker image**: `structurizr/structurizr`. The cloud service is scheduled to shut down on 30 September 2026.
+
+The previously separate tools (`structurizr/lite`, `structurizr-cli`, `structurizr/onpremises`) are now end-of-life and will receive no further updates. All CLI commands (`local`, `push`, `pull`, `export`, `validate`, `list`, `inspect`) are now subcommands of the unified image.
+
+Notably, the new `push` command no longer accepts a `-secret` flag. Authentication uses a single API key via `-key`.
+
+## Decision
+
+We migrate all Scaffoldizr tooling to exclusively use the unified `structurizr/structurizr` Docker image:
+
+1. **`run.sh`**: Changed from `structurizr/lite` to `docker run ... structurizr/structurizr local`. The `architecture/` folder is mounted as the Structurizr workspace root at `/usr/local/structurizr`.
+2. **`update.sh`**: Changed from `structurizr-cli push` to `docker run ... structurizr/structurizr push`. The `-secret` flag is dropped (no longer supported); only `-url`, `-id`, and `-key` are used. The `architecture/` folder is mounted and `workspace.json` is referenced at `/usr/local/structurizr/workspace.json`.
+3. **`--export` flag** in the CLI: Changed from spawning `structurizr-cli export` to `docker run ... structurizr/structurizr export -w ... -f json -o ...`.
+4. **AI Agent skill** (`.claude/skills/scaffoldizr/`): Updated all `structurizr-cli` references to use Docker equivalents with the correct `-w` flag.
+5. **`.env-arch` template**: Removed `STCTZR_WORKSPACE_SECRET` as it has no corresponding flag in the new image.
+
+The `structurizr-cli` binary dependency is fully dropped. Docker is now the sole runtime dependency for Structurizr operations.
+
+## Consequences
+
+**Positive:**
+- Users need only Docker installed — no separate `structurizr-cli` binary to download and manage.
+- All Structurizr operations use a single, consistent interface.
+- The project is insulated from the EOL of the standalone tools.
+- The `local` command is a drop-in replacement for Structurizr Lite with the same local authoring workflow.
+- Authentication is simplified to a single API key.
+
+**Negative:**
+- Docker must be running for any Structurizr operation (local viewing, export, push). Previously, `structurizr-cli` could be installed as a standalone binary without Docker.
+- First-time use of each command requires Docker to pull the `structurizr/structurizr` image (~1GB), adding latency.
+- Teams using `STCTZR_WORKSPACE_SECRET` in existing `.env-arch` files can safely remove it — the variable is no longer read.
+
+## References
+
+- [Introducing Structurizr vNext](https://www.patreon.com/posts/146923136) — Patreon post announcing the consolidation of all Structurizr tools into the unified image.
+- [Structurizr end-of-life page](https://docs.structurizr.com/eol) — Official EOL listing for Structurizr Lite, CLI, on-premises, and cloud service.
+- [Structurizr commands reference](https://docs.structurizr.com/commands) — Full list of commands available in the unified `structurizr/structurizr` image.
+- [local command reference](https://docs.structurizr.com/local) — Options and examples for the `local` command used in `run.sh`.

--- a/architecture/decisions/0004-windows-e2e-ci-smoke-only.md
+++ b/architecture/decisions/0004-windows-e2e-ci-smoke-only.md
@@ -1,0 +1,37 @@
+# 4. Windows CI E2E Tests Scoped to Version-Check Smoke Test Only
+
+Date: 2026-04-10
+
+## Status
+
+Accepted
+
+## Context
+
+- The `structurizr/structurizr` Docker image (introduced in ADR 0003) only provides Linux builds (`linux/amd64`, `linux/arm64`). There is no Windows-compatible Docker image.
+- The Scaffoldizr e2e test suite relies on the `structurizr/structurizr` Docker image for most tests (export, run, update scripts).
+- GitHub Actions Windows runners (`windows-latest`) cannot run Linux Docker containers without additional tooling (WSL2 + Docker Desktop license or equivalent), which is not available in standard CI environments.
+- Running the full e2e suite on Windows CI would require either: (a) a native Windows Structurizr binary (which does not exist), or (b) a Windows-compatible Docker image (which does not exist), or (c) mocking Docker entirely (which would reduce test fidelity).
+
+## Decision
+
+- Windows CI is scoped to a single **smoke test**: a version-check only (`scfz --version`) that validates the binary was built and runs correctly on Windows.
+- A dedicated npm script `test:e2e:smoke:windows` is added to `package.json`. It runs only `e2e/scfz-general.test.ts`, which contains the `@smoke` tagged version-check test and has zero Docker dependency.
+- The `.github/workflows/e2e.yaml` Windows job unconditionally runs `test:e2e:smoke:windows`. There is no full e2e path for Windows.
+- macOS and Linux CI jobs continue to run the full e2e suite (with Docker available via Colima on macOS, and natively on Linux runners).
+- Docker-dependent e2e tests are not tagged `@smoke` and are never run in the Windows job.
+
+## Consequences
+
+- Positive: Windows CI remains fast and reliable — no Docker dependency, no flaky Docker setup steps.
+- Positive: The Windows binary is still validated in CI for every PR (build succeeds + version output correct).
+- Positive: No licensing or infrastructure cost for Docker on Windows CI runners.
+- Negative: Docker-dependent scenarios (export, run, update scripts) are not tested on Windows in CI. Any Windows-specific Docker behaviour differences would only be caught locally or in production.
+- Negative: If a future Windows-compatible Structurizr Docker image becomes available, this ADR should be revisited to enable full e2e on Windows.
+
+## References
+
+- ADR 0003: Migrate to Unified Structurizr Docker Image
+- [structurizr/structurizr Docker Hub](https://hub.docker.com/r/structurizr/structurizr) — Linux-only image manifests
+- `.github/workflows/e2e.yaml` — CI workflow with platform-specific e2e steps
+- `package.json` `test:e2e:smoke:windows` script

--- a/architecture/decisions/0004-windows-e2e-ci-smoke-only.md
+++ b/architecture/decisions/0004-windows-e2e-ci-smoke-only.md
@@ -1,4 +1,4 @@
-# 4. Windows CI E2E Tests Scoped to Version-Check Smoke Test Only
+# 4. macOS and Windows CI E2E Tests Scoped to Version-Check Smoke Test Only
 
 Date: 2026-04-10
 
@@ -8,26 +8,28 @@ Accepted
 
 ## Context
 
-- The `structurizr/structurizr` Docker image (introduced in ADR 0003) only provides Linux builds (`linux/amd64`, `linux/arm64`). There is no Windows-compatible Docker image.
+- The `structurizr/structurizr` Docker image (introduced in ADR 0003) only provides Linux builds (`linux/amd64`, `linux/arm64`). There is no Windows or macOS-compatible Docker image.
 - The Scaffoldizr e2e test suite relies on the `structurizr/structurizr` Docker image for most tests (export, run, update scripts).
 - GitHub Actions Windows runners (`windows-latest`) cannot run Linux Docker containers without additional tooling (WSL2 + Docker Desktop license or equivalent), which is not available in standard CI environments.
-- Running the full e2e suite on Windows CI would require either: (a) a native Windows Structurizr binary (which does not exist), or (b) a Windows-compatible Docker image (which does not exist), or (c) mocking Docker entirely (which would reduce test fidelity).
+- GitHub Actions macOS runners (`macos-latest`) do not have Docker pre-installed, and neither VZ (Apple Virtualization.framework) nor QEMU-based VM solutions (e.g. Colima) work reliably on these runners due to missing hypervisor support.
+- Running the full e2e suite on macOS or Windows CI would require either: (a) a native binary for that platform (which does not exist), (b) a platform-compatible Docker image (which does not exist), or (c) mocking Docker entirely (which would reduce test fidelity).
 
 ## Decision
 
-- Windows CI is scoped to a single **smoke test**: a version-check only (`scfz --version`) that validates the binary was built and runs correctly on Windows.
-- A dedicated npm script `test:e2e:smoke:windows` is added to `package.json`. It runs only `e2e/scfz-general.test.ts`, which contains the `@smoke` tagged version-check test and has zero Docker dependency.
-- The `.github/workflows/e2e.yaml` Windows job unconditionally runs `test:e2e:smoke:windows`. There is no full e2e path for Windows.
-- macOS and Linux CI jobs continue to run the full e2e suite (with Docker available via Colima on macOS, and natively on Linux runners).
-- Docker-dependent e2e tests are not tagged `@smoke` and are never run in the Windows job.
+- macOS and Windows CI are both scoped to a single **smoke test**: a version-check only (`scfz --version`) that validates the binary was built and runs correctly on that platform.
+- A dedicated npm script `test:e2e:smoke:windows` is used for both macOS and Windows jobs. It runs only `e2e/scfz-general.test.ts`, which contains the `@smoke` tagged version-check test and has zero Docker dependency.
+- The `.github/workflows/e2e.yaml` macOS and Windows jobs unconditionally run `test:e2e:smoke:windows`. There is no full e2e path for either platform.
+- Linux CI jobs (`ubuntu-latest`) continue to run the full e2e suite with Docker available natively.
+- Docker-dependent e2e tests are not tagged `@smoke` and are never run in macOS or Windows jobs.
 
 ## Consequences
 
-- Positive: Windows CI remains fast and reliable — no Docker dependency, no flaky Docker setup steps.
-- Positive: The Windows binary is still validated in CI for every PR (build succeeds + version output correct).
-- Positive: No licensing or infrastructure cost for Docker on Windows CI runners.
-- Negative: Docker-dependent scenarios (export, run, update scripts) are not tested on Windows in CI. Any Windows-specific Docker behaviour differences would only be caught locally or in production.
-- Negative: If a future Windows-compatible Structurizr Docker image becomes available, this ADR should be revisited to enable full e2e on Windows.
+- Positive: macOS and Windows CI remain fast and reliable — no Docker dependency, no flaky VM/container setup steps.
+- Positive: Both macOS and Windows binaries are still validated in CI for every PR (build succeeds + version output correct).
+- Positive: No licensing or infrastructure cost for Docker on macOS/Windows CI runners.
+- Positive: Full e2e coverage is provided by Linux runners which have native Docker support.
+- Negative: Docker-dependent scenarios (export, run, update scripts) are not tested on macOS or Windows in CI. Any platform-specific behaviour differences would only be caught locally or in production.
+- Negative: If future macOS or Windows-compatible Structurizr Docker images become available, this ADR should be revisited.
 
 ## References
 

--- a/architecture/docs/02-getting-started.md
+++ b/architecture/docs/02-getting-started.md
@@ -28,4 +28,4 @@ where `{docs_folder}` is a folder where dsl files will be generated. The tool cr
 - `--help`: Show help information
 - `--version`: Show current tool version
 - `--dest <path>`: Target architecture folder (default: current directory)
-- `-e, --export`: Use structurizr-cli to export the workspace to JSON (default: false)
+- `-e, --export`: Use Structurizr unified CLI (Docker) to export the workspace to JSON (default: false)

--- a/architecture/docs/03-usage.md
+++ b/architecture/docs/03-usage.md
@@ -89,3 +89,72 @@ Once a workspace is initialized, use these subcommands:
 * **Color Theme Exclusivity**: The `theme` generator enforces that only one color-based theme (Blue, Red, Green, Yellow) can be active at a time. Selecting a new color theme automatically replaces the existing one.
 * **Decisions Folder**: Every scaffolded workspace includes an `architecture/decisions/` folder for Architecture Decision Records (ADRs).
 
+## Workspace Tooling
+
+Scaffoldizr generates helper scripts and an environment file to manage your workspace locally and remotely. These are located in the `architecture/scripts/` folder.
+
+> **Note**: All Structurizr operations now use the unified `structurizr/structurizr` Docker image, which replaces the previously separate `structurizr/lite` image and `structurizr-cli` tool. Docker must be installed and running.
+
+Both **Bash** (`.sh`) and **PowerShell** (`.ps1`) variants are generated for every script. Use the one that matches your operating system:
+
+| OS | Script |
+| :- | :----- |
+| macOS / Linux | `run.sh`, `update.sh` |
+| Windows | `run.ps1`, `update.ps1` |
+
+> **Windows users**: Run PowerShell scripts with `.\architecture\scripts\run.ps1` from a PowerShell terminal. If script execution is blocked, run `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned` once to allow local scripts.
+
+### run — View Workspace Locally
+
+Starts a local Structurizr server using Docker to visualize your architecture diagrams in the browser.
+
+```bash
+# macOS / Linux
+./architecture/scripts/run.sh [port]
+
+# Windows (PowerShell)
+.\architecture\scripts\run.ps1 [port]
+```
+
+- The optional `[port]` argument sets the local port (default: `8080`).
+- Access the workspace at `http://localhost:8080` after running.
+- The script validates that `workspace.json` exists before starting.
+- Stopping the script (Ctrl+C) automatically stops the Docker container.
+
+**How it works**: Mounts the `architecture/` folder into the Docker container and runs `structurizr/structurizr local`.
+
+### update — Push Workspace to Remote
+
+Pushes the compiled `workspace.json` to a remote Structurizr instance using the unified CLI.
+
+```bash
+# macOS / Linux
+./architecture/scripts/update.sh
+
+# Windows (PowerShell)
+.\architecture\scripts\update.ps1
+```
+
+- Requires a `.env-arch` file in the `architecture/` folder (see below).
+- Validates that `workspace.json` exists before pushing.
+- Performs a non-merging push — the remote workspace is fully replaced.
+
+**How it works**: Reads `architecture/.env-arch` for credentials, then runs `structurizr/structurizr push` inside Docker.
+
+For all available Structurizr CLI commands, see the [Structurizr commands reference](https://docs.structurizr.com/commands).
+
+### .env-arch — Remote Credentials
+
+The `architecture/.env-arch` file holds the authentication credentials required by `update.sh` / `update.ps1`. It is **not committed to version control**.
+
+Create an `.env-arch` file inside the `architecture/` folder with the following variables:
+
+```bash
+STCTZR_URL=https://api.structurizr.com
+STCTZR_WORKSPACE_ID=<your-workspace-id>
+STCTZR_WORKSPACE_KEY=<your-api-key>
+# STCTZR_PASSPHRASE=<your-passphrase>  # Optional: only required if client-side encryption is enabled on the workspace
+```
+
+You can find these values in your Structurizr workspace settings. `STCTZR_PASSPHRASE` is optional and only needed if you have enabled [client-side encryption](https://docs.structurizr.com/cloud/client-side-encryption) on your workspace.
+

--- a/architecture/docs/07-ai-agent.md
+++ b/architecture/docs/07-ai-agent.md
@@ -11,7 +11,15 @@ The AI Agent integration is designed for scenarios where:
 
 ## Installation
 
-The AI integration is available as a skill for agents that support OpenCode skills or similar tool-based environments. To enable it, ensure the Scaffoldizr CLI is installed in the agent's environment:
+The AI integration is available as a skill for agents that support OpenCode skills or similar tool-based environments.
+
+**Install the Scaffoldizr agent skill** (e.g. for OpenCode):
+
+```bash
+npx skills add formulamonks/scaffoldizr
+```
+
+Also ensure the Scaffoldizr CLI is installed in the agent's environment:
 
 ```bash
 curl -s https://formulamonks.github.io/scaffoldizr/assets/install.sh | sh
@@ -52,6 +60,6 @@ For a detailed list of subcommands and parameters, refer to the [Usage Guide](./
 
 * **Source**: The `architecture/workspace.dsl` file is the primary entry point.
 * **Compilation**: The DSL files are compiled into a single `architecture/workspace.json` file.
-* **Visualization**: Use the provided scripts (e.g., `architecture/scripts/run.sh`) to start Structurizr Lite and visualize diagrams at `http://localhost:8080`.
+* **Visualization**: Use the provided scripts (e.g., `architecture/scripts/run.sh`) to start Structurizr `local` and visualize diagrams at `http://localhost:8080`.
 
 Agents should never modify the `workspace.json` file directly; all changes should be made to the DSL source files.

--- a/architecture/scripts/run.ps1
+++ b/architecture/scripts/run.ps1
@@ -1,0 +1,28 @@
+$docsLocation = Split-Path -Parent $PSScriptRoot
+$port = if ($args[0]) { $args[0] } else { 8080 }
+
+if (-not (Test-Path "$docsLocation\workspace.json")) {
+    Write-Error "ERROR: workspace.json file not found in `"$docsLocation`" folder."
+    exit 1
+}
+
+$containerName = "structurizr-$(Split-Path -Leaf $docsLocation)-$port"
+
+function Stop-Container {
+    Write-Host "Stopping container $containerName..."
+    docker stop $containerName 2>$null
+}
+
+Write-Host "Running workspace: $docsLocation on port $port"
+
+$job = Start-Job -ScriptBlock {
+    param($containerName, $port, $docsLocation)
+    docker run -t --rm --name $containerName -p "${port}:8080" -v "${docsLocation}:/usr/local/structurizr" structurizr/structurizr local
+} -ArgumentList $containerName, $port, $docsLocation
+
+try {
+    Wait-Job $job
+} finally {
+    Stop-Container
+    Remove-Job $job -Force 2>$null
+}

--- a/architecture/scripts/run.ps1
+++ b/architecture/scripts/run.ps1
@@ -6,7 +6,10 @@ if (-not (Test-Path "$docsLocation\workspace.json")) {
     exit 1
 }
 
-$containerName = "structurizr-$(Split-Path -Leaf $docsLocation)-$port"
+$docsFolderName = Split-Path -Leaf $docsLocation
+$safeDocsFolderName = ($docsFolderName.ToLowerInvariant() -replace '[^a-z0-9_.-]', '-').Trim('-.')
+if (-not $safeDocsFolderName) { $safeDocsFolderName = "workspace" }
+$containerName = "structurizr-$safeDocsFolderName-$port"
 
 function Stop-Container {
     Write-Host "Stopping container $containerName..."
@@ -15,14 +18,8 @@ function Stop-Container {
 
 Write-Host "Running workspace: $docsLocation on port $port"
 
-$job = Start-Job -ScriptBlock {
-    param($containerName, $port, $docsLocation)
-    docker run -t --rm --name $containerName -p "${port}:8080" -v "${docsLocation}:/usr/local/structurizr" structurizr/structurizr local
-} -ArgumentList $containerName, $port, $docsLocation
-
 try {
-    Wait-Job $job
+    docker run -t --rm --name $containerName -p "${port}:8080" -v "${docsLocation}:/usr/local/structurizr" structurizr/structurizr local
 } finally {
     Stop-Container
-    Remove-Job $job -Force 2>$null
 }

--- a/architecture/scripts/run.sh
+++ b/architecture/scripts/run.sh
@@ -2,6 +2,23 @@
 
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 port=${1:-8080}
+
+# Check if workspace.json file exists
+if [ ! -e "${docs_location}/workspace.json" ]; then
+    echo "ERROR: workspace.json file not found in \"${docs_location}\" folder.";
+    exit 1;
+fi
+
+container_name="structurizr-$(basename "${docs_location}")-${port}"
+
+cleanup() {
+    echo "Stopping container ${container_name}..."
+    docker stop "${container_name}" 2>/dev/null
+}
+
+trap cleanup SIGTERM SIGINT
+
 echo "Running workspace: ${docs_location} on port ${port}"
 
-docker run -t --rm -p "${port}":8080 -v "${docs_location}:/usr/local/structurizr" structurizr/lite
+docker run -t --rm --name "${container_name}" -p "${port}":8080 -v "${docs_location}:/usr/local/structurizr" structurizr/structurizr local &
+wait $!

--- a/architecture/scripts/run.sh
+++ b/architecture/scripts/run.sh
@@ -9,7 +9,9 @@ if [ ! -e "${docs_location}/workspace.json" ]; then
     exit 1;
 fi
 
-container_name="structurizr-$(basename "${docs_location}")-${port}"
+docs_basename=$(basename "${docs_location}")
+sanitized_docs_basename=$(printf '%s' "${docs_basename}" | sed 's/[^A-Za-z0-9_.-]/-/g')
+container_name="structurizr-${sanitized_docs_basename}-${port}"
 
 cleanup() {
     echo "Stopping container ${container_name}..."

--- a/architecture/scripts/update.ps1
+++ b/architecture/scripts/update.ps1
@@ -16,6 +16,10 @@ Get-Content "$docsLocation\.env-arch" | ForEach-Object {
     if ($_ -match '^\s*#') { return }
     if ($_ -match '^\s*$') { return }
     $parts = $_ -split '=', 2
+    if ($parts.Length -lt 2) {
+        Write-Error "ERROR: Malformed .env-arch entry: `"$($_)`". Expected KEY=VALUE format."
+        exit 1
+    }
     [System.Environment]::SetEnvironmentVariable($parts[0].Trim(), $parts[1].Trim().Trim('"'), 'Process')
 }
 

--- a/architecture/scripts/update.ps1
+++ b/architecture/scripts/update.ps1
@@ -1,0 +1,33 @@
+$docsLocation = Split-Path -Parent $PSScriptRoot
+
+Write-Host "Updating workspace: $docsLocation"
+
+if (-not (Test-Path "$docsLocation\workspace.json")) {
+    Write-Error "ERROR: workspace.json file not found in `"$docsLocation`" folder."
+    exit 1
+}
+
+if (-not (Test-Path "$docsLocation\.env-arch")) {
+    Write-Error "ERROR: .env-arch file not found in `"$docsLocation`" folder."
+    exit 1
+}
+
+Get-Content "$docsLocation\.env-arch" | ForEach-Object {
+    if ($_ -match '^\s*#') { return }
+    if ($_ -match '^\s*$') { return }
+    $parts = $_ -split '=', 2
+    [System.Environment]::SetEnvironmentVariable($parts[0].Trim(), $parts[1].Trim().Trim('"'), 'Process')
+}
+
+$passphraseArg = @()
+if ($env:STCTZR_PASSPHRASE) {
+    $passphraseArg = @("-passphrase", $env:STCTZR_PASSPHRASE)
+}
+
+docker run -t --rm -v "${docsLocation}:/usr/local/structurizr" structurizr/structurizr push `
+    -url $env:STCTZR_URL `
+    -id $env:STCTZR_WORKSPACE_ID `
+    -key $env:STCTZR_WORKSPACE_KEY `
+    -w /usr/local/structurizr/workspace.json `
+    -merge false `
+    @passphraseArg

--- a/architecture/scripts/update.sh
+++ b/architecture/scripts/update.sh
@@ -15,9 +15,9 @@ fi
 
 source "${docs_location}/.env-arch"
 
-passphrase_arg=""
+passphrase_args=()
 if [ -n "${STCTZR_PASSPHRASE}" ]; then
-    passphrase_arg="-passphrase \"${STCTZR_PASSPHRASE}\""
+    passphrase_args+=(-passphrase "${STCTZR_PASSPHRASE}")
 fi
 
-eval docker run -t --rm -v "${docs_location}:/usr/local/structurizr" structurizr/structurizr push -url "$STCTZR_URL" -id "$STCTZR_WORKSPACE_ID" -key "$STCTZR_WORKSPACE_KEY" -w /usr/local/structurizr/workspace.json -merge false ${passphrase_arg}
+docker run -t --rm -v "${docs_location}:/usr/local/structurizr" structurizr/structurizr push -url "$STCTZR_URL" -id "$STCTZR_WORKSPACE_ID" -key "$STCTZR_WORKSPACE_KEY" -w /usr/local/structurizr/workspace.json -merge false "${passphrase_args[@]}"

--- a/architecture/scripts/update.sh
+++ b/architecture/scripts/update.sh
@@ -3,9 +3,21 @@
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 echo "Updating workspace: ${docs_location}"
 
+if [ ! -e "${docs_location}/workspace.json" ]; then
+    echo "ERROR: workspace.json file not found in \"${docs_location}\" folder.";
+    exit 1;
+fi
+
 if [ ! -e "${docs_location}/.env-arch" ]; then
     echo "ERROR: .env-arch file not found in \"${docs_location}\" folder.";
     exit 1;
 fi
 
-source "${docs_location}/.env-arch" && structurizr-cli push -url "$STCTZR_URL" -id "$STCTZR_WORKSPACE_ID" -key "$STCTZR_WORKSPACE_KEY" -secret "$STCTZR_WORKSPACE_SECRET" -w "${docs_location}/workspace.json" -merge false%
+source "${docs_location}/.env-arch"
+
+passphrase_arg=""
+if [ -n "${STCTZR_PASSPHRASE}" ]; then
+    passphrase_arg="-passphrase \"${STCTZR_PASSPHRASE}\""
+fi
+
+eval docker run -t --rm -v "${docs_location}:/usr/local/structurizr" structurizr/structurizr push -url "$STCTZR_URL" -id "$STCTZR_WORKSPACE_ID" -key "$STCTZR_WORKSPACE_KEY" -w /usr/local/structurizr/workspace.json -merge false ${passphrase_arg}

--- a/architecture/workspace.dsl
+++ b/architecture/workspace.dsl
@@ -31,7 +31,7 @@ workspace "Scaffoldizr" {
     }
 
     views {
-        themes "https://static.structurizr.com/themes/default/theme.json" "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json" "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-status.json" "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-red.json"
+        themes "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json" "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-status.json" "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-default.json"
         !const AUTHOR "Author: Formula.monks <andres.zorro@mediamonks.com>"
 
         !include views

--- a/architecture/workspace.json
+++ b/architecture/workspace.json
@@ -11,6 +11,20 @@
       "id" : "1",
       "status" : "Accepted",
       "title" : "Record architecture decisions"
+    }, {
+      "content" : "# 2. Support AI Agent and Non-Interactive Mode\n\nDate: 2026-04-08\n\n## Status\n\nAccepted\n\n## Context\n\nScaffoldizr was originally designed as a fully interactive CLI tool, relying on Inquirer.js prompts to guide users through workspace and element creation. This worked well for human operators but made the tool unusable in automated contexts.\n\nAs AI-assisted development workflows became common, agents (such as LLM-based coding assistants) needed to generate and evolve architecture documentation programmatically. These agents cannot interact with TTY-based prompts and require all inputs to be provided upfront as CLI flags.\n\nAdditionally, the rise of standardized agent skill formats (e.g., OpenCode / Claude skills) created an opportunity to package Scaffoldizr's conventions and generator knowledge into a reusable agent skill, enabling AI assistants to invoke the tool correctly without human guidance.\n\n## Decision\n\nWe will extend the CLI to support non-interactive execution by:\n\n1. **Subcommand routing** — when a `workspace.dsl` already exists, the desired generator can be passed as a positional subcommand (e.g., `scfz container`), bypassing the interactive main menu.\n2. **Flag-based answers** — all Inquirer prompt questions can be answered via CLI flags using `--parameter \"value\"` format. When all required flags are present, no prompts are shown.\n3. **AI Agent Skill** — a structured skill file (`.claude/skills/scaffoldizr/SKILL.md`) is shipped with the repository, providing AI agents with conventions, element creation rules, workspace scope constraints, and CLI usage patterns.\n\nThe interactive mode remains fully supported and is unchanged. Non-interactive mode is strictly additive.\n\n## Consequences\n\n**Positive:**\n- AI agents and automation scripts can drive the full Scaffoldizr workflow without human input.\n- The agent skill codifies existing conventions, reducing the risk of agents generating invalid or inconsistent DSL.\n- CI pipelines can scaffold architecture elements as part of automated workflows.\n- The tool surface area for human users is unchanged — interactive mode is unaffected.\n\n**Negative:**\n- CLI flag names are tightly coupled to Inquirer prompt `name` fields. Renaming a prompt question is now a breaking change for any automation that targets that flag.\n- Non-interactive mode does not validate flag completeness upfront — missing required flags fall back to interactive prompts, which will hang in a non-TTY context.\n- The agent skill file must be kept in sync with generator changes manually; there is no automated validation that the skill reflects current CLI behaviour.\n",
+      "date" : "2026-04-08T00:00:00Z",
+      "format" : "Markdown",
+      "id" : "2",
+      "status" : "Accepted",
+      "title" : "Support AI Agent and Non-Interactive Mode"
+    }, {
+      "content" : "# 3. Migrate to Unified Structurizr Docker Image\n\nDate: 2026-04-10\n\n## Status\n\nAccepted\n\n## Context\n\nScaffoldizr relied on two separate Structurizr tools:\n\n1. **`structurizr/lite`** Docker image — used by `run.sh` to serve the workspace locally for authoring and visualization.\n2. **`structurizr-cli`** standalone binary — used by `update.sh` to push the workspace to a remote Structurizr instance, and by the CLI's `--export` flag to compile `workspace.dsl` to `workspace.json`.\n\nIn late 2025, Structurizr announced the consolidation of all its tools — Structurizr Lite, Structurizr CLI, and Structurizr on-premises — into a **single unified tool and Docker image**: `structurizr/structurizr`. The cloud service is scheduled to shut down on 30 September 2026.\n\nThe previously separate tools (`structurizr/lite`, `structurizr-cli`, `structurizr/onpremises`) are now end-of-life and will receive no further updates. All CLI commands (`local`, `push`, `pull`, `export`, `validate`, `list`, `inspect`) are now subcommands of the unified image.\n\nNotably, the new `push` command no longer accepts a `-secret` flag. Authentication uses a single API key via `-key`.\n\n## Decision\n\nWe migrate all Scaffoldizr tooling to exclusively use the unified `structurizr/structurizr` Docker image:\n\n1. **`run.sh`**: Changed from `structurizr/lite` to `docker run ... structurizr/structurizr local`. The `architecture/` folder is mounted as the Structurizr workspace root at `/usr/local/structurizr`.\n2. **`update.sh`**: Changed from `structurizr-cli push` to `docker run ... structurizr/structurizr push`. The `-secret` flag is dropped (no longer supported); only `-url`, `-id`, and `-key` are used. The `architecture/` folder is mounted and `workspace.json` is referenced at `/usr/local/structurizr/workspace.json`.\n3. **`--export` flag** in the CLI: Changed from spawning `structurizr-cli export` to `docker run ... structurizr/structurizr export -w ... -f json -o ...`.\n4. **AI Agent skill** (`.claude/skills/scaffoldizr/`): Updated all `structurizr-cli` references to use Docker equivalents with the correct `-w` flag.\n5. **`.env-arch` template**: Removed `STCTZR_WORKSPACE_SECRET` as it has no corresponding flag in the new image.\n\nThe `structurizr-cli` binary dependency is fully dropped. Docker is now the sole runtime dependency for Structurizr operations.\n\n## Consequences\n\n**Positive:**\n- Users need only Docker installed — no separate `structurizr-cli` binary to download and manage.\n- All Structurizr operations use a single, consistent interface.\n- The project is insulated from the EOL of the standalone tools.\n- The `local` command is a drop-in replacement for Structurizr Lite with the same local authoring workflow.\n- Authentication is simplified to a single API key.\n\n**Negative:**\n- Docker must be running for any Structurizr operation (local viewing, export, push). Previously, `structurizr-cli` could be installed as a standalone binary without Docker.\n- First-time use of each command requires Docker to pull the `structurizr/structurizr` image (~1GB), adding latency.\n- Teams using `STCTZR_WORKSPACE_SECRET` in existing `.env-arch` files can safely remove it — the variable is no longer read.\n\n## References\n\n- [Introducing Structurizr vNext](https://www.patreon.com/posts/146923136) — Patreon post announcing the consolidation of all Structurizr tools into the unified image.\n- [Structurizr end-of-life page](https://docs.structurizr.com/eol) — Official EOL listing for Structurizr Lite, CLI, on-premises, and cloud service.\n- [Structurizr commands reference](https://docs.structurizr.com/commands) — Full list of commands available in the unified `structurizr/structurizr` image.\n- [local command reference](https://docs.structurizr.com/local) — Options and examples for the `local` command used in `run.sh`.\n",
+      "date" : "2026-04-10T00:00:00Z",
+      "format" : "Markdown",
+      "id" : "3",
+      "status" : "Accepted",
+      "title" : "Migrate to Unified Structurizr Docker Image"
     } ],
     "sections" : [ {
       "content" : "\n## Motivation\n\n[Structurizr Workspaces](https://docs.structurizr.com/workspaces) are a great way to document and share architecture diagrams in the [C4 model](https://c4model.com/). However, the diagram creation is freeform and there are no guidelines to break code into files, leaving architects and developers with a feeling of not knowing where to start.\n\nThis is an opinionated scaffolding tool written in TypeScript/[Bun](https://bun.sh/) that attempts to create the building blocks of a solid system architecture documentation, that eases up the entry barrier for newcomers as well as allowing architects experienced in Structurizr to follow a convention while setting them up for success.\n",
@@ -19,13 +33,13 @@
       "order" : 1,
       "title" : ""
     }, {
-      "content" : "\n## Installation\n\nRun in your terminal:\n\n```bash\ncurl -s https://formulamonks.github.io/scaffoldizr/assets/install.sh | sh\n```\n\nThen, verify the tool is correctly installed:\n\n```bash\nscfz --version\n```\n\n## Usage\n\nOnce installed, run in your terminal:\n\n```bash\nscfz --dest {docs_folder}\n```\n\nwhere `{docs_folder}` is a folder where dsl files will be generated. The tool creates an `architecture/` folder and starts scaffolding from there. `{docs_folder}` default value is current working directory. So you can just issue `scfz` command.\n\n### Options\n\n- `--help`: Show help information\n- `--version`: Show current tool version\n- `--dest <path>`: Target architecture folder (default: current directory)\n- `-e, --export`: Use structurizr-cli to export the workspace to JSON (default: false)\n",
+      "content" : "\n## Installation\n\nRun in your terminal:\n\n```bash\ncurl -s https://formulamonks.github.io/scaffoldizr/assets/install.sh | sh\n```\n\nThen, verify the tool is correctly installed:\n\n```bash\nscfz --version\n```\n\n## Usage\n\nOnce installed, run in your terminal:\n\n```bash\nscfz --dest {docs_folder}\n```\n\nwhere `{docs_folder}` is a folder where dsl files will be generated. The tool creates an `architecture/` folder and starts scaffolding from there. `{docs_folder}` default value is current working directory. So you can just issue `scfz` command.\n\n### Options\n\n- `--help`: Show help information\n- `--version`: Show current tool version\n- `--dest <path>`: Target architecture folder (default: current directory)\n- `-e, --export`: Use Structurizr unified CLI (Docker) to export the workspace to JSON (default: false)\n",
       "filename" : "02-getting-started.md",
       "format" : "Markdown",
       "order" : 2,
       "title" : ""
     }, {
-      "content" : "\n## CLI Usage\n\nWhen you run Scaffoldizr:\n\n1. The CLI displays a welcome message\n2. It checks if the destination folder contains a `workspace.dsl` file\n3. If no workspace is found, it automatically initiates the workspace creation generator\n4. You'll be prompted with interactive questions to configure your workspace\n5. The tool generates the appropriate scaffolding based on your answers\n\n## Supported Elements\n\n| Element | Description | Prompts |\n| :-----: | :---------- | :------ |\n| `Workspace` | Creates a new workspace with proper scaffolding. Automatically triggered when no `workspace.dsl` file is found. Creates workspace structure including `workspace.dsl`, system files, relationships, and configuration files. | Workspace name, description, scope (Software System/Landscape), system details (if applicable), author info (from git config), theme preference |\n| `🟡 Constant` | Reusable constant that can be referenced across diagrams and relationships. Appends the constant definition to `workspace.dsl`. | Constant name, value |\n| `🔺 Archetype` | [Reusable element templates](https://docs.structurizr.com/dsl/archetypes) (Container, Component, Software System, or Relationship). Creates `architecture/archetypes/{name}_{baseType}.dsl`. | Archetype name, base type, optional technology, optional tags |\n| `👤 Person` | An actor or user interacting with systems. Creates/appends to `systems/_people.dsl` and `relationships/_people.dsl`. | Person name, description, relationships, technology |\n| `🟦 System` | Creates a system. Available for landscape scope only. (See [scope](https://docs.structurizr.com/workspaces/scope)) | System name, description, relationships |\n| `⬜️ External System` | Creates an external system not owned by the development team (e.g., third-party dependencies, external APIs). Appends to `systems/_external.dsl` and `relationships/_external.dsl`. | Parent system, external system name, description, relationships |\n| `🔷 Container` | Creates a deployable/executable unit within a system (web app, database, API, message broker, etc.). Creates container file, view, and relationship files. Supports types: EventBus, MessageBroker, Function, Database, WebApp, MobileApp. | Parent system, container name, description, type, technology, relationships |\n| `🔹 Component` | Creates a component within a container (controller, service, repository, etc.). Requires at least one existing container. Creates/updates component files, includes, views, and relationships. | Parent container, component name, description, technology, relationships |\n| `🔳 View` | Creates Structurizr views for visualizing architecture. Supports Deployment and Landscape view types. Creates view files and environment configurations. See [Supported View Types](#supported-view-types) below. | View type, system name (if needed), view name, description, instance details (for deployment) |\n\n## Supported View Types\n\n| View type | Description |\n| :-------: | :---------- |\n| `landscape` | System Landscape view. Showcases system and external relationships. |\n| `deployment` | Useful for displaying infrastructure and resources. |\n",
+      "content" : "\n## CLI Usage\n\nWhen you run Scaffoldizr:\n\n1. The CLI displays a welcome message\n2. It checks if the destination folder contains a `workspace.dsl` file\n3. If no workspace is found, it automatically initiates the workspace creation generator\n4. You'll be prompted with interactive questions to configure your workspace\n5. The tool generates the appropriate scaffolding based on your answers\n\n## Supported Elements\n\n| Element | Description | Prompts |\n| :-----: | :---------- | :------ |\n| `Workspace` | Creates a new workspace with proper scaffolding. Automatically triggered when no `workspace.dsl` file is found. Creates workspace structure including `workspace.dsl`, system files, relationships, and configuration files. | Workspace name, description, scope (Software System/Landscape), system details (if applicable), author info (from git config), theme preference |\n| `🟡 Constant` | Reusable constant that can be referenced across diagrams and relationships. Appends the constant definition to `workspace.dsl`. | Constant name, value |\n| `🔺 Archetype` | [Reusable element templates](https://docs.structurizr.com/dsl/archetypes) (Container, Component, Software System, or Relationship). Creates `architecture/archetypes/{name}_{baseType}.dsl`. | Archetype name, base type, optional technology, optional tags |\n| `👤 Person` | An actor or user interacting with systems. Creates/appends to `systems/_people.dsl` and `relationships/_people.dsl`. | Person name, description, relationships, technology |\n| `🟦 System` | Creates a system. Available for landscape scope only. (See [scope](https://docs.structurizr.com/workspaces/scope)) | System name, description, relationships |\n| `⬜️ External System` | Creates an external system not owned by the development team (e.g., third-party dependencies, external APIs). Appends to `systems/_external.dsl` and `relationships/_external.dsl`. | Parent system, external system name, description, relationships |\n| `🔷 Container` | Creates a deployable/executable unit within a system (web app, database, API, message broker, etc.). Creates container file, view, and relationship files. Supports types: EventBus, MessageBroker, Function, Database, WebApp, MobileApp. | Parent system, container name, description, type, technology, relationships |\n| `🔹 Component` | Creates a component within a container (controller, service, repository, etc.). Requires at least one existing container. Creates/updates component files, includes, views, and relationships. | Parent container, component name, description, technology, relationships |\n| `🔳 View` | Creates Structurizr views for visualizing architecture. Supports Deployment and Landscape view types. Creates view files and environment configurations. See [Supported View Types](#supported-view-types) below. | View type, system name (if needed), view name, description, instance details (for deployment) |\n| `🎨 Theme` | Manage workspace themes (add, remove, list). Updates the `themes` line in `architecture/workspace.dsl`. Available in both Landscape and SoftwareSystem scopes. | `themeAction`, `additionalThemes` |\n\n## Supported View Types\n\n| View type | Description |\n| :-------: | :---------- |\n| `landscape` | System Landscape view. Showcases system and external relationships. |\n| `deployment` | Useful for displaying infrastructure and resources. |\n\n## Non-Interactive Usage (AI Agent Mode)\n\nScaffoldizr supports non-interactive execution by routing to specific subcommands and passing parameters as CLI flags. This mode is ideal for AI agents or automation scripts.\n\n### Subcommand Routing\n\nWhen a workspace already exists, you can bypass the main menu by specifying a generator as a subcommand:\n\n```bash\nscfz <generator> [options]\n```\n\n### Passing Arguments\n\nAll prompt questions can be answered via CLI flags using `--parameter \"value\"` or `--parameter=value` format.\n\n#### Workspace Generator (Initial Setup)\n\nUsed when no `workspace.dsl` exists in the destination:\n\n```bash\nscfz --dest \".\" \\\n  --workspaceName \"My Workspace\" \\\n  --workspaceDescription \"A sample workspace\" \\\n  --workspaceScope \"softwaresystem\" \\\n  --systemName \"My System\" \\\n  --systemDescription \"Core system\" \\\n  --authorName \"Jane Doe\" \\\n  --authorEmail \"jane@example.com\" \\\n  --shouldIncludeTheme \"false\"\n```\n\n#### Element Generators\n\nOnce a workspace is initialized, use these subcommands:\n\n| Generator | Description | Common Arguments |\n| :-------: | :---------- | :--------------- |\n| `system` | Software System | `--systemName`, `--systemDescription`, `--archetype` |\n| `container` | Container | `--systemName` (parent), `--elementName`, `--containerDescription`, `--containerType`, `--containerTechnology` |\n| `component` | Component | `--elementName`, `--componentDescription`, `--componentTechnology` |\n| `person` | Person | `--elementName`, `--personDescription` |\n| `external-system` | External System | `--elementName`, `--extSystemDescription` |\n| `view` | View | `--viewType` (landscape/deployment), `--viewName`, `--viewDescription` |\n| `constant` | Constant | `--constantName`, `--constantValue` |\n| `archetype` | Archetype | `--archetypeName`, `--archetypeDescription` |\n| `theme` | Manage Themes | `--themeAction \"Add themes\" --additionalThemes \"<url1>,<url2>\"` |\n\n### Scope and Validation Rules\n\n* **Scope Restriction**: Generators are restricted by the workspace scope defined in `workspace.dsl`.\n  * **Landscape**: Allows `system`, `person`, `external-system`, `view`, `relationship`, `constant`, `archetype`.\n  * **SoftwareSystem**: Allows `container`, `component`, `person`, `external-system`, `view`, `relationship`, `constant`, `archetype`.\n  * Using an unsupported generator for the current scope will result in a non-zero exit code.\n* **Uniqueness Validation**: Element names must be unique. If a duplicate name is provided in non-interactive mode, the command will fail with exit code 1.\n* **Color Theme Exclusivity**: The `theme` generator enforces that only one color-based theme (Blue, Red, Green, Yellow) can be active at a time. Selecting a new color theme automatically replaces the existing one.\n* **Decisions Folder**: Every scaffolded workspace includes an `architecture/decisions/` folder for Architecture Decision Records (ADRs).\n\n## Workspace Tooling\n\nScaffoldizr generates helper scripts and an environment file to manage your workspace locally and remotely. These are located in the `architecture/scripts/` folder.\n\n> **Note**: All Structurizr operations now use the unified `structurizr/structurizr` Docker image, which replaces the previously separate `structurizr/lite` image and `structurizr-cli` tool. Docker must be installed and running.\n\nBoth **Bash** (`.sh`) and **PowerShell** (`.ps1`) variants are generated for every script. Use the one that matches your operating system:\n\n| OS | Script |\n| :- | :----- |\n| macOS / Linux | `run.sh`, `update.sh` |\n| Windows | `run.ps1`, `update.ps1` |\n\n> **Windows users**: Run PowerShell scripts with `.\\architecture\\scripts\\run.ps1` from a PowerShell terminal. If script execution is blocked, run `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned` once to allow local scripts.\n\n### run — View Workspace Locally\n\nStarts a local Structurizr server using Docker to visualize your architecture diagrams in the browser.\n\n```bash\n# macOS / Linux\n./architecture/scripts/run.sh [port]\n\n# Windows (PowerShell)\n.\\architecture\\scripts\\run.ps1 [port]\n```\n\n- The optional `[port]` argument sets the local port (default: `8080`).\n- Access the workspace at `http://localhost:8080` after running.\n- The script validates that `workspace.json` exists before starting.\n- Stopping the script (Ctrl+C) automatically stops the Docker container.\n\n**How it works**: Mounts the `architecture/` folder into the Docker container and runs `structurizr/structurizr local`.\n\n### update — Push Workspace to Remote\n\nPushes the compiled `workspace.json` to a remote Structurizr instance using the unified CLI.\n\n```bash\n# macOS / Linux\n./architecture/scripts/update.sh\n\n# Windows (PowerShell)\n.\\architecture\\scripts\\update.ps1\n```\n\n- Requires a `.env-arch` file in the `architecture/` folder (see below).\n- Validates that `workspace.json` exists before pushing.\n- Performs a non-merging push — the remote workspace is fully replaced.\n\n**How it works**: Reads `architecture/.env-arch` for credentials, then runs `structurizr/structurizr push` inside Docker.\n\nFor all available Structurizr CLI commands, see the [Structurizr commands reference](https://docs.structurizr.com/commands).\n\n### .env-arch — Remote Credentials\n\nThe `architecture/.env-arch` file holds the authentication credentials required by `update.sh` / `update.ps1`. It is **not committed to version control**.\n\nCreate an `.env-arch` file inside the `architecture/` folder with the following variables:\n\n```bash\nSTCTZR_URL=https://api.structurizr.com\nSTCTZR_WORKSPACE_ID=<your-workspace-id>\nSTCTZR_WORKSPACE_KEY=<your-api-key>\n# STCTZR_PASSPHRASE=<your-passphrase>  # Optional: only required if client-side encryption is enabled on the workspace\n```\n\nYou can find these values in your Structurizr workspace settings. `STCTZR_PASSPHRASE` is optional and only needed if you have enabled [client-side encryption](https://docs.structurizr.com/cloud/client-side-encryption) on your workspace.\n\n",
       "filename" : "03-usage.md",
       "format" : "Markdown",
       "order" : 3,
@@ -43,16 +57,21 @@
       "order" : 5,
       "title" : ""
     }, {
-      "content" : "## Themes\n\nScaffoldizr includes some extra themes extending from the default Structurizr theme. [More information here](https://docs.structurizr.com/ui/diagrams/themes).\n\n### How to reference\n\nWithin your `workspace.dsl`, add the following line under `views`:\n\n```dsl\n\nviews {\n    themes \"<url to theme 1>.json\" \"<url to theme 2>.json\"\n}\n\n```\n\n---\n\n### Shapes\n\nAdded tag support to most available shapes within Structurizr.\n\n![Scaffoldizr Shapes](https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.png)\n\n```dsl\nthemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json\"\n```\n\n### Status\n\nAdded handy representations for elements when they need to be added/removed from a system or if they are external, inactive, etc.\n\n![Scaffoldizr Status](https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-status.png)\n\n```dsl\nthemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-status.json\"\n```\n\n### Color-based\n\nBecause not all diagrams have to be architecture blue!\n\n#### Green\n\n![Scaffoldizr Green](https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-green.png)\n\n```dsl\nthemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-green.json\"\n```\n\n#### Yellow\n\n![Scaffoldizr Yellow](https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-yellow.png)\n\n```dsl\nthemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-yellow.json\"\n```\n\n#### Red\n\n![Scaffoldizr Red](https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-red.png)\n\n```dsl\nthemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-red.json\"\n```\n",
+      "content" : "\n\n## Managing Themes with Scaffoldizr\n\nUse the `theme` generator to manage your workspace themes without manually editing the DSL.\n\n### Interactive\n\nRun `scfz theme` to launch the interactive theme manager. It provides three actions:\n\n- **Add themes**: select from built-in themes or enter a custom URL.\n- **Remove themes**: select currently configured themes to remove.\n- **List themes**: see all theme URLs currently used in your workspace.\n\nColor-based themes (Blue, Red, Green, Yellow) are mutually exclusive. Selecting a new color theme automatically replaces any existing one.\n\n### Non-Interactive (AI Agent Mode)\n\nUse the `theme` subcommand with flags for automation:\n\n- `--themeAction`: one of `\"Add themes\"`, `\"Remove themes\"`, or `\"List themes\"`.\n- `--additionalThemes`: comma-separated theme URLs to add (e.g. `\"url1,url2\"`).\n\nFor example, to add the Shapes theme:\n\n```bash\nscfz theme \\\n  --themeAction \"Add themes\" \\\n  --additionalThemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json\"\n```\n\nThe Blue color theme, which is not included by default during workspace initialization, can be added using:\n\n```bash\nscfz theme \\\n  --themeAction \"Add themes\" \\\n  --additionalThemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-blue.json\"\n```\n\n## Available Themes\n\n\nScaffoldizr includes some extra themes extending from the default Structurizr theme. [More information here](https://docs.structurizr.com/ui/diagrams/themes).\n\n### How to reference\n\nWithin your `workspace.dsl`, add the following line under `views`:\n\n```dsl\n\nviews {\n    themes \"<url to theme 1>.json\" \"<url to theme 2>.json\"\n}\n\n```\n\n---\n\n## Shapes\n\nAdded tag support to most available shapes within Structurizr.\n\n![Scaffoldizr Shapes](https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.png)\n\n```dsl\nthemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json\"\n```\n\n## Status\n\nAdded handy representations for elements when they need to be added/removed from a system or if they are external, inactive, etc.\n\n![Scaffoldizr Status](https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-status.png)\n\n```dsl\nthemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-status.json\"\n```\n\n## Color-based\n\nBecause not all diagrams have to be architecture blue!\n\n### Green\n\n![Scaffoldizr Green](https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-green.png)\n\n```dsl\nthemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-green.json\"\n```\n\n### Yellow\n\n![Scaffoldizr Yellow](https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-yellow.png)\n\n```dsl\nthemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-yellow.json\"\n```\n\n### Red\n\n![Scaffoldizr Red](https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-red.png)\n\n```dsl\nthemes \"https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-red.json\"\n```\n",
       "filename" : "06-themes.md",
       "format" : "Markdown",
       "order" : 6,
       "title" : ""
+    }, {
+      "content" : "\nScaffoldizr provides an opinionated framework for AI agents to generate and interact with [Structurizr workspaces](https://docs.structurizr.com/workspaces). By following a consistent folder structure and non-interactive CLI patterns, AI agents can reliably build and maintain C4 model architecture documentation.\n\n## Overview\n\nThe AI Agent integration is designed for scenarios where:\n\n* An AI agent needs to create or update elements within a Structurizr workspace.\n* Architecture diagrams (leveraging the C4 model) need to be generated automatically.\n* An existing Structurizr workspace requires validation or refactoring.\n\n## Installation\n\nThe AI integration is available as a skill for agents that support OpenCode skills or similar tool-based environments.\n\n**Install the Scaffoldizr agent skill** (e.g. for OpenCode):\n\n```bash\nnpx skills add formulamonks/scaffoldizr\n```\n\nAlso ensure the Scaffoldizr CLI is installed in the agent's environment:\n\n```bash\ncurl -s https://formulamonks.github.io/scaffoldizr/assets/install.sh | sh\n```\n\nThe agent should then have access to the `scfz` command for non-interactive operations.\n\n## Folder Structure\n\nScaffoldizr generates a predictable folder structure within the `architecture/` directory, making it easy for AI agents to locate and modify specific architectural elements:\n\n* `archetypes/`: Reusable relationship patterns and baseline elements.\n* `systems/`: Software system definitions, including people (`_people.dsl`) and external systems (`_external.dsl`).\n* `containers/<system name>/`: Container definitions for a specific software system.\n* `components/<system name>/<container name>/`: Component definitions for a specific container.\n* `relationships/`: Global relationship definitions between elements.\n* `views/`: View definitions for rendering diagrams (context, container, component, etc.).\n* `decisions/`: Architecture Decision Records (ADRs) documenting key design choices.\n* `docs/`: Documentation files referenced within the workspace.\n* `environments/`: Deployment nodes and infrastructure definitions.\n\n## Workspace Scope\n\nAI agents must respect the workspace scope defined in `architecture/workspace.dsl`. The scope determines which elements can be created:\n\n1.  **Landscape Scope**: Allows creating `system`, `person`, `external-system`, `view`, `relationship`, `constant`, and `archetype`.\n2.  **SoftwareSystem Scope**: Allows creating `container`, `component`, `person`, `external-system`, `view`, `relationship`, `constant`, and `archetype`.\n\nAgents should verify the current scope before attempting to scaffold new elements to ensure consistency with the C4 model levels.\n\n## Creating Elements\n\nAI agents interact with the workspace using the `scfz` CLI tool in non-interactive mode. This is achieved by passing arguments as flags to bypass interactive prompts.\n\nFor a detailed list of subcommands and parameters, refer to the [Usage Guide](./03-usage.md).\n\n## Workspace Build Process\n\n* **Source**: The `architecture/workspace.dsl` file is the primary entry point.\n* **Compilation**: The DSL files are compiled into a single `architecture/workspace.json` file.\n* **Visualization**: Use the provided scripts (e.g., `architecture/scripts/run.sh`) to start Structurizr `local` and visualize diagrams at `http://localhost:8080`.\n\nAgents should never modify the `workspace.json` file directly; all changes should be made to the DSL source files.\n",
+      "filename" : "07-ai-agent.md",
+      "format" : "Markdown",
+      "order" : 7,
+      "title" : ""
     } ]
   },
   "id" : 1,
-  "lastModifiedAgent" : "structurizr-ui",
-  "lastModifiedDate" : "2025-12-01T22:37:40Z",
+  "lastModifiedDate" : "2026-04-10T17:04:35Z",
   "model" : {
     "people" : [ {
       "description" : "Architect",
@@ -93,8 +112,8 @@
       "tags" : "Element,Person"
     } ],
     "properties" : {
-      "structurizr.inspection.model.softwaresystem.decisions" : "ignore",
-      "structurizr.inspection.model.softwaresystem.documentation" : "ignore"
+      "structurizr.inspection.model.softwaresystem.documentation" : "ignore",
+      "structurizr.inspection.model.softwaresystem.decisions" : "ignore"
     },
     "softwareSystems" : [ {
       "description" : "Local instance for Structurizr diagram visualization.",
@@ -248,43 +267,39 @@
   },
   "name" : "Scaffoldizr",
   "properties" : {
+    "structurizr.inspection.error" : "0",
     "structurizr.inspection.info" : "0",
     "structurizr.inspection.ignore" : "2",
-    "structurizr.inspection.error" : "0",
     "structurizr.inspection.warning" : "0"
   },
   "views" : {
     "componentViews" : [ {
       "containerId" : "4",
       "description" : "Definition to generate files and folders. Author: Formula.monks <andres.zorro@mediamonks.com>",
-      "dimensions" : {
-        "height" : 1515,
-        "width" : 3632
-      },
       "elements" : [ {
         "id" : "2",
-        "x" : 2982,
-        "y" : 759
+        "x" : 0,
+        "y" : 0
       }, {
         "id" : "5",
-        "x" : 1650,
-        "y" : 192
+        "x" : 0,
+        "y" : 0
       }, {
         "id" : "6",
-        "x" : 2397,
-        "y" : 192
+        "x" : 0,
+        "y" : 0
       }, {
         "id" : "7",
-        "x" : 2023,
-        "y" : 759
+        "x" : 0,
+        "y" : 0
       }, {
         "id" : "8",
-        "x" : 892,
-        "y" : 192
+        "x" : 0,
+        "y" : 0
       }, {
         "id" : "9",
-        "x" : 200,
-        "y" : 142
+        "x" : 0,
+        "y" : 0
       } ],
       "externalContainerBoundariesVisible" : false,
       "key" : "Generator",
@@ -305,40 +320,31 @@
       } ]
     } ],
     "configuration" : {
-      "branding" : { },
-      "lastSavedView" : "ScaffoldizrCLI",
-      "metadataSymbols" : "SquareBrackets",
       "styles" : { },
       "terminology" : { },
-      "themes" : [ "https://static.structurizr.com/themes/default/theme.json", "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json", "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-status.json", "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-red.json" ]
+      "themes" : [ "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json", "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-status.json", "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-default.json" ]
     },
     "containerViews" : [ {
       "automaticLayout" : {
-        "applied" : true,
-        "edgeSeparation" : 0,
-        "implementation" : "Graphviz",
-        "nodeSeparation" : 300,
+        "edgeSeparation" : 50,
+        "nodeSeparation" : 50,
         "rankDirection" : "LeftRight",
-        "rankSeparation" : 300,
-        "vertices" : false
+        "rankSeparation" : 100,
+        "vertices" : true
       },
       "description" : "Command Line Interface (binary). Author: Formula.monks <andres.zorro@mediamonks.com>",
-      "dimensions" : {
-        "height" : 820,
-        "width" : 2350
-      },
       "elements" : [ {
         "id" : "2",
-        "x" : 1699,
-        "y" : 163
+        "x" : 0,
+        "y" : 0
       }, {
         "id" : "4",
-        "x" : 949,
-        "y" : 163
+        "x" : 0,
+        "y" : 0
       }, {
         "id" : "9",
-        "x" : 199,
-        "y" : 163
+        "x" : 0,
+        "y" : 0
       } ],
       "externalSoftwareSystemBoundariesVisible" : false,
       "key" : "ScaffoldizrCLI",
@@ -353,26 +359,22 @@
     } ],
     "systemContextViews" : [ {
       "description" : "Scaffolding tool. Author: Formula.monks <andres.zorro@mediamonks.com>",
-      "dimensions" : {
-        "height" : 1730,
-        "width" : 2350
-      },
       "elements" : [ {
         "id" : "1",
-        "x" : 939,
-        "y" : 1172
+        "x" : 0,
+        "y" : 0
       }, {
         "id" : "2",
-        "x" : 1699,
-        "y" : 617
+        "x" : 0,
+        "y" : 0
       }, {
         "id" : "3",
-        "x" : 939,
-        "y" : 142
+        "x" : 0,
+        "y" : 0
       }, {
         "id" : "9",
-        "x" : 199,
-        "y" : 567
+        "x" : 0,
+        "y" : 0
       } ],
       "enterpriseBoundaryVisible" : true,
       "key" : "Scaffoldizr",

--- a/docs/assets/scaffoldizr-default.json
+++ b/docs/assets/scaffoldizr-default.json
@@ -1,0 +1,39 @@
+{
+    "name": "Structurizr Default Theme",
+    "description": "Default Structurizr theme — self-hosted copy of https://static.structurizr.com/themes/default/theme.json",
+    "elements": [
+        {
+            "tag": "Boundary:Container",
+            "color": "#438dd5"
+        },
+        {
+            "tag": "Boundary:SoftwareSystem",
+            "color": "#1168bd"
+        },
+        {
+            "tag": "Component",
+            "background": "#85bbf0",
+            "color": "#ffffff"
+        },
+        {
+            "tag": "Container",
+            "background": "#438dd5",
+            "color": "#ffffff"
+        },
+        {
+            "tag": "Element",
+            "shape": "RoundedBox"
+        },
+        {
+            "tag": "Person",
+            "background": "#08427b",
+            "color": "#ffffff",
+            "shape": "Person"
+        },
+        {
+            "tag": "Software System",
+            "background": "#1168bd",
+            "color": "#ffffff"
+        }
+    ]
+}

--- a/e2e/scfz-landscape.test.ts
+++ b/e2e/scfz-landscape.test.ts
@@ -50,6 +50,16 @@ describe("e2e: landscape", () => {
             `${folder}/architecture/workspace.dsl`,
         ).text();
         expect(workspaceContents).toContain("Test Workspace");
+
+        const scriptsContents = await readdir(`${folder}/architecture/scripts`);
+        expect(scriptsContents).toEqual(
+            expect.arrayContaining([
+                "run.sh",
+                "update.sh",
+                "run.ps1",
+                "update.ps1",
+            ]),
+        );
     });
 
     test("@smoke: should add a new system", async () => {

--- a/e2e/scfz-softwaresystem.test.ts
+++ b/e2e/scfz-softwaresystem.test.ts
@@ -51,6 +51,16 @@ describe("e2e: Software System", () => {
             `${folder}/architecture/workspace.dsl`,
         ).text();
         expect(workspaceContents).toContain("Test Workspace");
+
+        const scriptsContents = await readdir(`${folder}/architecture/scripts`);
+        expect(scriptsContents).toEqual(
+            expect.arrayContaining([
+                "run.sh",
+                "update.sh",
+                "run.ps1",
+                "update.ps1",
+            ]),
+        );
     });
 
     test("should add a new constant", async () => {

--- a/lib/generators/workspace.ts
+++ b/lib/generators/workspace.ts
@@ -217,6 +217,12 @@ const generator: GeneratorDefinition<WorkspaceAnswers> = {
         {
             type: "addMany",
             destination: "architecture",
+            templateFiles: "templates/scripts/**/*.ps1",
+            skipIfExists: true,
+        } as AddManyAction<WorkspaceAnswers>,
+        {
+            type: "addMany",
+            destination: "architecture",
             templateFiles: "templates/**/.gitkeep",
         } as AddManyAction<WorkspaceAnswers>,
         {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -30,9 +30,6 @@ type CLIArguments = {
     _?: (string | number)[];
 };
 
-const STRUCTURIZR_CLI_PATH =
-    process.env.STRUCTURIZR_CLI_PATH || "structurizr-cli";
-
 async function main(args: CLIArguments = { dest: "." }) {
     console.log(
         chalk.bold(`
@@ -49,7 +46,7 @@ Create a Structurizr DSL scaffolding in seconds!
         const workspacePath = getWorkspacePath(path);
         if (!workspacePath) return;
 
-        return $`${STRUCTURIZR_CLI_PATH} export -w ${workspacePath}/workspace.dsl -f json -o ${workspacePath} || true`;
+        return $`docker run -t --rm -v ${workspacePath}:/usr/local/structurizr structurizr/structurizr export -w /usr/local/structurizr/workspace.dsl -f json -o /usr/local/structurizr || true`;
     };
 
     const { workspaceGenerator, ...otherGenerators } = generators;
@@ -224,7 +221,7 @@ if (["main.ts", "scfz"].includes(basename(entrypoint))) {
             alias: "e",
             type: "boolean",
             default: false,
-            desc: "Use structurizr-cli to export the workspace to JSON",
+            desc: "Use Structurizr unified CLI (Docker) to export the workspace to JSON",
         }).argv;
 
     main(args);

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -21,7 +21,11 @@ import {
     SORTED_GENERATOR_AVAILABLE_ELEMENTS,
 } from "./utils/labels";
 import { checkUpdate } from "./utils/update";
-import { getWorkspaceJson, getWorkspacePath } from "./utils/workspace";
+import {
+    getWorkspaceDslScope,
+    getWorkspaceJson,
+    getWorkspacePath,
+} from "./utils/workspace";
 
 type CLIArguments = {
     dest: string;
@@ -91,6 +95,10 @@ Let's create a new one by answering the questions below.
         getWorkspacePath(workspacePath),
     );
 
+    const workspaceScope =
+        workspaceInfo?.configuration?.scope ??
+        (await getWorkspaceDslScope(workspacePath));
+
     console.log(
         chalk.gray(`Workspace name: ${chalk.cyan(workspaceInfo?.name)}`),
     );
@@ -103,7 +111,7 @@ Let's create a new one by answering the questions below.
     );
 
     const filteredGenerators = Object.values(otherGenerators).filter((g) => {
-        if (!workspaceInfo) return true;
+        if (!workspaceScope) return true;
 
         const sharedElements: string[] = [
             Elements.Archetype,
@@ -116,7 +124,7 @@ Let's create a new one by answering the questions below.
             Elements.Theme,
         ];
 
-        if (workspaceInfo.configuration.scope === "Landscape") {
+        if (workspaceScope === "Landscape") {
             return [...sharedElements, Elements.System].includes(g.name);
         } else {
             return [

--- a/lib/templates/.env-arch.hbs
+++ b/lib/templates/.env-arch.hbs
@@ -2,4 +2,4 @@
 STCTZR_URL=""
 STCTZR_WORKSPACE_ID=""
 STCTZR_WORKSPACE_KEY=""
-STCTZR_WORKSPACE_SECRET=""
+# STCTZR_PASSPHRASE=""  # Optional: only required if client-side encryption is enabled on the workspace

--- a/lib/templates/bundle.ts
+++ b/lib/templates/bundle.ts
@@ -11,7 +11,9 @@ import environmentsDeployment from "./environments/deployment.hbs";
 import include from "./include.hbs";
 import relationshipsMultiple from "./relationships/multiple.hbs";
 import relationshipsMultipleComponent from "./relationships/multiple-component.hbs";
+import scriptsRunPs1 from "./scripts/run.ps1" with { type: "file" };
 import scriptsRun from "./scripts/run.sh" with { type: "file" };
+import scriptsUpdatePs1 from "./scripts/update.ps1" with { type: "file" };
 import scriptsUpdate from "./scripts/update.sh" with { type: "file" };
 import systemExternal from "./system/external.hbs";
 import systemPerson from "./system/person.hbs";
@@ -47,7 +49,9 @@ const templatesMap = new Map([
         relationshipsMultipleComponent,
     ],
     ["templates/scripts/run.sh", scriptsRun],
+    ["templates/scripts/run.ps1", scriptsRunPs1],
     ["templates/scripts/update.sh", scriptsUpdate],
+    ["templates/scripts/update.ps1", scriptsUpdatePs1],
     ["templates/system/external.hbs", systemExternal],
     ["templates/system/person.hbs", systemPerson],
     ["templates/system/system.hbs", systemSystem],

--- a/lib/templates/scripts/run.ps1
+++ b/lib/templates/scripts/run.ps1
@@ -1,0 +1,28 @@
+$docsLocation = Split-Path -Parent $PSScriptRoot
+$port = if ($args[0]) { $args[0] } else { 8080 }
+
+if (-not (Test-Path "$docsLocation\workspace.json")) {
+    Write-Error "ERROR: workspace.json file not found in `"$docsLocation`" folder."
+    exit 1
+}
+
+$containerName = "structurizr-$(Split-Path -Leaf $docsLocation)-$port"
+
+function Stop-Container {
+    Write-Host "Stopping container $containerName..."
+    docker stop $containerName 2>$null
+}
+
+Write-Host "Running workspace: $docsLocation on port $port"
+
+$job = Start-Job -ScriptBlock {
+    param($containerName, $port, $docsLocation)
+    docker run -t --rm --name $containerName -p "${port}:8080" -v "${docsLocation}:/usr/local/structurizr" structurizr/structurizr local
+} -ArgumentList $containerName, $port, $docsLocation
+
+try {
+    Wait-Job $job
+} finally {
+    Stop-Container
+    Remove-Job $job -Force 2>$null
+}

--- a/lib/templates/scripts/run.ps1
+++ b/lib/templates/scripts/run.ps1
@@ -6,7 +6,10 @@ if (-not (Test-Path "$docsLocation\workspace.json")) {
     exit 1
 }
 
-$containerName = "structurizr-$(Split-Path -Leaf $docsLocation)-$port"
+$docsFolderName = Split-Path -Leaf $docsLocation
+$safeDocsFolderName = ($docsFolderName.ToLowerInvariant() -replace '[^a-z0-9_.-]', '-').Trim('-.')
+if (-not $safeDocsFolderName) { $safeDocsFolderName = "workspace" }
+$containerName = "structurizr-$safeDocsFolderName-$port"
 
 function Stop-Container {
     Write-Host "Stopping container $containerName..."
@@ -15,14 +18,8 @@ function Stop-Container {
 
 Write-Host "Running workspace: $docsLocation on port $port"
 
-$job = Start-Job -ScriptBlock {
-    param($containerName, $port, $docsLocation)
-    docker run -t --rm --name $containerName -p "${port}:8080" -v "${docsLocation}:/usr/local/structurizr" structurizr/structurizr local
-} -ArgumentList $containerName, $port, $docsLocation
-
 try {
-    Wait-Job $job
+    docker run -t --rm --name $containerName -p "${port}:8080" -v "${docsLocation}:/usr/local/structurizr" structurizr/structurizr local
 } finally {
     Stop-Container
-    Remove-Job $job -Force 2>$null
 }

--- a/lib/templates/scripts/run.sh
+++ b/lib/templates/scripts/run.sh
@@ -2,6 +2,23 @@
 
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 port=${1:-8080}
+
+# Check if workspace.json file exists
+if [ ! -e "${docs_location}/workspace.json" ]; then
+    echo "ERROR: workspace.json file not found in \"${docs_location}\" folder.";
+    exit 1;
+fi
+
+container_name="structurizr-$(basename "${docs_location}")-${port}"
+
+cleanup() {
+    echo "Stopping container ${container_name}..."
+    docker stop "${container_name}" 2>/dev/null
+}
+
+trap cleanup SIGTERM SIGINT
+
 echo "Running workspace: ${docs_location} on port ${port}"
 
-docker run -t --rm -p "${port}":8080 -v "${docs_location}:/usr/local/structurizr" structurizr/lite
+docker run -t --rm --name "${container_name}" -p "${port}":8080 -v "${docs_location}:/usr/local/structurizr" structurizr/structurizr local &
+wait $!

--- a/lib/templates/scripts/run.sh
+++ b/lib/templates/scripts/run.sh
@@ -9,7 +9,9 @@ if [ ! -e "${docs_location}/workspace.json" ]; then
     exit 1;
 fi
 
-container_name="structurizr-$(basename "${docs_location}")-${port}"
+docs_basename=$(basename "${docs_location}")
+sanitized_docs_basename=$(printf '%s' "${docs_basename}" | sed 's/[^A-Za-z0-9_.-]/-/g')
+container_name="structurizr-${sanitized_docs_basename}-${port}"
 
 cleanup() {
     echo "Stopping container ${container_name}..."

--- a/lib/templates/scripts/update.ps1
+++ b/lib/templates/scripts/update.ps1
@@ -16,6 +16,10 @@ Get-Content "$docsLocation\.env-arch" | ForEach-Object {
     if ($_ -match '^\s*#') { return }
     if ($_ -match '^\s*$') { return }
     $parts = $_ -split '=', 2
+    if ($parts.Length -lt 2) {
+        Write-Error "ERROR: Malformed .env-arch entry: `"$($_)`". Expected KEY=VALUE format."
+        exit 1
+    }
     [System.Environment]::SetEnvironmentVariable($parts[0].Trim(), $parts[1].Trim().Trim('"'), 'Process')
 }
 

--- a/lib/templates/scripts/update.ps1
+++ b/lib/templates/scripts/update.ps1
@@ -1,0 +1,33 @@
+$docsLocation = Split-Path -Parent $PSScriptRoot
+
+Write-Host "Updating workspace: $docsLocation"
+
+if (-not (Test-Path "$docsLocation\workspace.json")) {
+    Write-Error "ERROR: workspace.json file not found in `"$docsLocation`" folder."
+    exit 1
+}
+
+if (-not (Test-Path "$docsLocation\.env-arch")) {
+    Write-Error "ERROR: .env-arch file not found in `"$docsLocation`" folder."
+    exit 1
+}
+
+Get-Content "$docsLocation\.env-arch" | ForEach-Object {
+    if ($_ -match '^\s*#') { return }
+    if ($_ -match '^\s*$') { return }
+    $parts = $_ -split '=', 2
+    [System.Environment]::SetEnvironmentVariable($parts[0].Trim(), $parts[1].Trim().Trim('"'), 'Process')
+}
+
+$passphraseArg = @()
+if ($env:STCTZR_PASSPHRASE) {
+    $passphraseArg = @("-passphrase", $env:STCTZR_PASSPHRASE)
+}
+
+docker run -t --rm -v "${docsLocation}:/usr/local/structurizr" structurizr/structurizr push `
+    -url $env:STCTZR_URL `
+    -id $env:STCTZR_WORKSPACE_ID `
+    -key $env:STCTZR_WORKSPACE_KEY `
+    -w /usr/local/structurizr/workspace.json `
+    -merge false `
+    @passphraseArg

--- a/lib/templates/scripts/update.sh
+++ b/lib/templates/scripts/update.sh
@@ -15,9 +15,9 @@ fi
 
 source "${docs_location}/.env-arch"
 
-passphrase_arg=""
+passphrase_args=()
 if [ -n "${STCTZR_PASSPHRASE}" ]; then
-    passphrase_arg="-passphrase \"${STCTZR_PASSPHRASE}\""
+    passphrase_args+=(-passphrase "${STCTZR_PASSPHRASE}")
 fi
 
-eval docker run -t --rm -v "${docs_location}:/usr/local/structurizr" structurizr/structurizr push -url "$STCTZR_URL" -id "$STCTZR_WORKSPACE_ID" -key "$STCTZR_WORKSPACE_KEY" -w /usr/local/structurizr/workspace.json -merge false ${passphrase_arg}
+docker run -t --rm -v "${docs_location}:/usr/local/structurizr" structurizr/structurizr push -url "$STCTZR_URL" -id "$STCTZR_WORKSPACE_ID" -key "$STCTZR_WORKSPACE_KEY" -w /usr/local/structurizr/workspace.json -merge false "${passphrase_args[@]}"

--- a/lib/templates/scripts/update.sh
+++ b/lib/templates/scripts/update.sh
@@ -3,9 +3,21 @@
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 echo "Updating workspace: ${docs_location}"
 
+if [ ! -e "${docs_location}/workspace.json" ]; then
+    echo "ERROR: workspace.json file not found in \"${docs_location}\" folder.";
+    exit 1;
+fi
+
 if [ ! -e "${docs_location}/.env-arch" ]; then
     echo "ERROR: .env-arch file not found in \"${docs_location}\" folder.";
     exit 1;
 fi
 
-source "${docs_location}/.env-arch" && structurizr-cli push -url "$STCTZR_URL" -id "$STCTZR_WORKSPACE_ID" -key "$STCTZR_WORKSPACE_KEY" -secret "$STCTZR_WORKSPACE_SECRET" -w "${docs_location}/workspace.json" -merge false%
+source "${docs_location}/.env-arch"
+
+passphrase_arg=""
+if [ -n "${STCTZR_PASSPHRASE}" ]; then
+    passphrase_arg="-passphrase \"${STCTZR_PASSPHRASE}\""
+fi
+
+eval docker run -t --rm -v "${docs_location}:/usr/local/structurizr" structurizr/structurizr push -url "$STCTZR_URL" -id "$STCTZR_WORKSPACE_ID" -key "$STCTZR_WORKSPACE_KEY" -w /usr/local/structurizr/workspace.json -merge false ${passphrase_arg}

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -22,6 +22,12 @@ declare module "*.sh" {
     export default content;
 }
 
+declare module "*.ps1" {
+    const content: string;
+
+    export default content;
+}
+
 declare module "*.json" {
     const content: Record<string, unknown>;
 

--- a/lib/utils/themes.ts
+++ b/lib/utils/themes.ts
@@ -1,5 +1,5 @@
 export const STRUCTURIZR_DEFAULT_THEME_URL =
-    "https://static.structurizr.com/themes/default/theme.json";
+    "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-default.json";
 export const SCAFFOLDIZR_SHAPES_THEME_URL =
     "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-shapes.json";
 export const SCAFFOLDIZR_STATUS_THEME_URL =

--- a/lib/utils/workspace.ts
+++ b/lib/utils/workspace.ts
@@ -159,6 +159,20 @@ export const getWorkspaceJson = async (
     return undefined;
 };
 
+export const getWorkspaceDslScope = async (
+    workspaceFolder: string | undefined,
+): Promise<"SoftwareSystem" | "Landscape" | undefined> => {
+    if (!workspaceFolder) return undefined;
+    const dslFile = file(join(workspaceFolder, "workspace.dsl"));
+    if (dslFile.size === 0) return undefined;
+    const content = await dslFile.text();
+    const match = content.match(/scope\s+(softwaresystem|landscape)/i);
+    if (!match) return undefined;
+    return match[1].toLowerCase() === "softwaresystem"
+        ? "SoftwareSystem"
+        : "Landscape";
+};
+
 export type WorkspaceElement = {
     name: string;
     parent?: string;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "test": "bun test",
         "test:ci": "bun test --coverage",
         "test:e2e:smoke": "bun --config=./e2e/e2e.toml test -t '@smoke' --bail --timeout 30000",
+        "test:e2e:smoke:windows": "bun --config=./e2e/e2e.toml test ./e2e/scfz-general.test.ts --bail --timeout 30000",
         "test:e2e": "bun --config=./e2e/e2e.toml test --bail --timeout 30000",
         "prepare": "husky",
         "docs:serve": "cd docs && bundle exec jekyll serve --watch --livereload --config _config.yml,_config.local.yml"

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -61,7 +61,7 @@ export const createFullWorkspace = async (basePath: string): Promise<void> => {
     }
 
     views {
-        themes "https://static.structurizr.com/themes/default/theme.json"
+        themes "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-default.json"
         !const AUTHOR "Author: Test User <test@example.com>"
 
         !include views


### PR DESCRIPTION
## Summary

- Replaces all usage of the deprecated `structurizr/lite` image and `structurizr-cli` binary with the unified `structurizr/structurizr` Docker image across scripts, templates, CLI export, and AI agent skill instructions
- Adds PowerShell (`run.ps1`, `update.ps1`) variants of the workspace scripts alongside the existing Bash scripts, always generating both so teams on any OS are covered
- Self-hosts the Structurizr default theme (`scaffoldizr-default.json`) to avoid dependency on `static.structurizr.com` which will go offline when the cloud service reaches EOL on 30 September 2026

## Changes

### Scripts & Templates
- `architecture/scripts/run.sh` + `lib/templates/scripts/run.sh`: updated to `structurizr/structurizr local`, named container, SIGTERM/SIGINT trap for graceful shutdown
- `architecture/scripts/update.sh` + `lib/templates/scripts/update.sh`: replaced `structurizr-cli push` with `docker run ... structurizr/structurizr push`; added optional `-passphrase` support for client-side encryption
- **New**: `architecture/scripts/run.ps1`, `architecture/scripts/update.ps1` and their template equivalents — PowerShell variants with equivalent logic
- `lib/templates/.env-arch.hbs`: removed `STCTZR_WORKSPACE_SECRET` (no longer supported); added optional `STCTZR_PASSPHRASE`

### CLI (`lib/main.ts`)
- Removed `STRUCTURIZR_CLI_PATH` constant; `--export` flag now runs `docker run ... structurizr/structurizr export`

### Theme
- `docs/assets/scaffoldizr-default.json`: self-hosted copy of the Structurizr default theme
- `lib/utils/themes.ts`: `STRUCTURIZR_DEFAULT_THEME_URL` now points to the self-hosted asset

### Code Infrastructure
- `lib/types.d.ts`: added `*.ps1` module declaration
- `lib/templates/bundle.ts`: registered `run.ps1` and `update.ps1` templates
- `lib/generators/workspace.ts`: added second `addMany` action for `.ps1` scripts
- `test/utils.ts`: updated hardcoded theme URL in test fixture

### Documentation
- `architecture/decisions/0003-unified-structurizr-docker.md` + `docs/_adrs/0003-unified-structurizr-docker.md`: new ADR documenting the migration with full references
- `architecture/docs/03-usage.md`: updated Workspace Tooling section — OS table, both Bash/PowerShell invocations, Windows execution policy hint, SIGTERM note
- `architecture/docs/02-getting-started.md`: updated `--export` flag description
- `architecture/docs/07-ai-agent.md` + `README.md`: added `npx skills add formulamonks/scaffoldizr` installation instruction
- `.claude/skills/scaffoldizr/`: updated all CLI references to use Docker equivalents

## References
- [Introducing Structurizr vNext](https://www.patreon.com/posts/146923136)
- [Structurizr end-of-life page](https://docs.structurizr.com/eol)
- [Structurizr commands reference](https://docs.structurizr.com/commands)
- [push command reference](https://docs.structurizr.com/push)