### PR TITLE
fix(migrate): inject version at build time via SCFZ_VERSION

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -114,10 +114,11 @@ jobs:
           $pkg.version = $version
           $pkg | ConvertTo-Json -Depth 100 | Set-Content package.json
       - name: Create binary and release files
+        env:
+          SCFZ_VERSION: ${{ needs.output-version.outputs.version }}
         run: |
-          jq -r '.version' package.json
           mkdir -p ./dist/${{ matrix.name }}
-          bun build ./lib/main.ts --compile --outfile ./dist/${{ matrix.name }}/scfz
+          bun build ./lib/main.ts --compile --define "SCFZ_VERSION=\"$SCFZ_VERSION\"" --outfile ./dist/${{ matrix.name }}/scfz
           ./dist/${{ matrix.name }}/scfz --version
           cd ./dist
           tar -czvf scfz-${{ matrix.name }}.tar.gz ./${{ matrix.name }}

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -119,7 +119,7 @@ jobs:
           SCFZ_VERSION: ${{ needs.output-version.outputs.version }}
         run: |
           mkdir -p ./dist/${{ matrix.name }}
-          bun build ./lib/main.ts --compile --define "SCFZ_VERSION=\"$SCFZ_VERSION\"" --outfile ./dist/${{ matrix.name }}/scfz
+          bun build ./lib/main.ts --compile --define "process.env.SCFZ_VERSION=\"$SCFZ_VERSION\"" --outfile ./dist/${{ matrix.name }}/scfz
           ./dist/${{ matrix.name }}/scfz --version
           cd ./dist
           tar -czvf scfz-${{ matrix.name }}.tar.gz ./${{ matrix.name }}

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -114,6 +114,7 @@ jobs:
           $pkg.version = $version
           $pkg | ConvertTo-Json -Depth 100 | Set-Content package.json
       - name: Create binary and release files
+        shell: bash
         env:
           SCFZ_VERSION: ${{ needs.output-version.outputs.version }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ web_modules/
 
 # TypeScript cache
 
-\*.tsbuildinfo
+*.tsbuildinfo
 
 # Optional npm cache directory
 

--- a/lib/generators/workspace.ts
+++ b/lib/generators/workspace.ts
@@ -1,10 +1,10 @@
 import { $ } from "bun";
-import pkg from "../../package.json";
 import type { AddAction, AddManyAction } from "../utils/actions";
 import type { GeneratorDefinition } from "../utils/generator";
 import { Elements } from "../utils/labels";
 import { checkbox, confirm, input, select } from "../utils/prompts";
 import { stringEmpty } from "../utils/questions/validators";
+import { scfzVersion } from "../utils/scfz-version";
 import {
     SCAFFOLDIZR_GREEN_THEME_URL,
     SCAFFOLDIZR_RED_THEME_URL,
@@ -148,7 +148,7 @@ const generator: GeneratorDefinition<WorkspaceAnswers> = {
                 ...additionalThemes,
                 mainColor,
             ].filter(Boolean) as string[],
-            scaffoldizrVersion: pkg.version,
+            scaffoldizrVersion: scfzVersion,
         };
     },
     actions: [

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -21,6 +21,7 @@ import {
     labelElementByName,
     SORTED_GENERATOR_AVAILABLE_ELEMENTS,
 } from "./utils/labels";
+import { scfzVersion } from "./utils/scfz-version";
 import { checkUpdate } from "./utils/update";
 import { isNewerVersion } from "./utils/version";
 import {
@@ -80,7 +81,7 @@ Let's create a new one by answering the questions below.
             await exportWorkspace(
                 relative(process.cwd(), destPath) || process.cwd(),
             );
-            const updateMessage = await checkUpdate(pkg.version);
+            const updateMessage = await checkUpdate(scfzVersion);
             if (updateMessage) console.log(updateMessage);
             process.exit(0);
         } catch (err) {
@@ -117,7 +118,7 @@ Let's create a new one by answering the questions below.
     const wsVersion = await getWorkspaceVersion(
         `${workspacePath}/workspace.dsl`,
     );
-    if (isNewerVersion(pkg.version, wsVersion)) {
+    if (isNewerVersion(scfzVersion, wsVersion)) {
         const line1 = "⚠  Your workspace might be outdated.";
         const line2 = "Migrate it using: scfz migrate";
         const line3 =
@@ -195,7 +196,7 @@ Let's create a new one by answering the questions below.
 
             await createGenerator(directGenerator);
             await exportWorkspace(relative(process.cwd(), workspacePath));
-            const updateMessage = await checkUpdate(pkg.version);
+            const updateMessage = await checkUpdate(scfzVersion);
             if (updateMessage) console.log(updateMessage);
             process.exit(0);
         }
@@ -230,7 +231,7 @@ Let's create a new one by answering the questions below.
 
         await createGenerator(generator);
         await exportWorkspace(relative(process.cwd(), workspacePath));
-        const updateMessage = await checkUpdate(pkg.version);
+        const updateMessage = await checkUpdate(scfzVersion);
         if (updateMessage) console.log(updateMessage);
         process.exit(0);
     } catch (err) {
@@ -248,7 +249,7 @@ export default main;
 
 if (["main.ts", "scfz"].includes(basename(entrypoint))) {
     const args: CLIArguments = await yargs(hideBin(process.argv))
-        .version("version", "Show current tool version", pkg.version)
+        .version("version", "Show current tool version", scfzVersion)
         .usage(
             `${capitalCase(
                 pkg.name,

--- a/lib/migrations/add-version-header.migration.ts
+++ b/lib/migrations/add-version-header.migration.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import chalk from "chalk";
+import { scfzVersion } from "../utils/scfz-version";
 import {
     getWorkspaceVersion,
     updateWorkspaceVersion,
@@ -31,7 +32,7 @@ export const addVersionHeaderMigration: Migration = {
             return { applied: false, description, filesChanged: [] };
         }
 
-        await updateWorkspaceVersion(workspaceDslPath, "0.10.0", dryRun);
+        await updateWorkspaceVersion(workspaceDslPath, scfzVersion, dryRun);
         return { applied: true, description, filesChanged: ["workspace.dsl"] };
     },
 };

--- a/lib/migrations/index.ts
+++ b/lib/migrations/index.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import chalk from "chalk";
-import pkg from "../../package.json";
+import { scfzVersion } from "../utils/scfz-version";
 import { isNewerVersion } from "../utils/version";
 import {
     getWorkspaceVersion,
@@ -22,7 +22,7 @@ export async function runMigrations(
 ): Promise<void> {
     const workspaceDslPath = resolve(workspacePath, "workspace.dsl");
     const currentVersion = await getWorkspaceVersion(workspaceDslPath);
-    const targetVersion = pkg.version;
+    const targetVersion = scfzVersion;
 
     console.log(
         `Migrating workspace from v${currentVersion} to v${targetVersion}${dryRun ? " (DRY RUN)" : ""}\n`,

--- a/lib/utils/scfz-version.ts
+++ b/lib/utils/scfz-version.ts
@@ -1,3 +1,10 @@
 import pkg from "../../package.json";
 
-export const scfzVersion: string = process.env.SCFZ_VERSION ?? pkg.version;
+const normalizedScfzVersion = process.env.SCFZ_VERSION?.trim().replace(
+    /^v/,
+    "",
+);
+
+export const scfzVersion: string = normalizedScfzVersion
+    ? normalizedScfzVersion
+    : pkg.version;

--- a/lib/utils/scfz-version.ts
+++ b/lib/utils/scfz-version.ts
@@ -1,0 +1,3 @@
+import pkg from "../../package.json";
+
+export const scfzVersion: string = process.env.SCFZ_VERSION ?? pkg.version;


### PR DESCRIPTION
## Summary

- Fixes a bug where `scfz migrate` stamped legacy workspaces with the hardcoded version `0.10.0` instead of the actual running CLI version
- Introduces `lib/utils/scfz-version.ts` as a single source of truth for the CLI version: reads `process.env.SCFZ_VERSION` (injected at compile time via `--define` in CI) with a fallback to `pkg.version` for local dev
- Replaces all direct `pkg.version` usages across `main.ts`, `workspace.ts`, `migrations/index.ts`, and `add-version-header.migration.ts` with the new `scfzVersion` export
- Updates `test-build.yaml` to pass `SCFZ_VERSION` as an env var to the `bun build --compile --define` command, reusing the existing `SCFZ_VERSION` convention already established in the release scripts