### PR TITLE
fix: add missing indentation when inserting themes line

### DIFF
--- a/e2e/scfz-theme.test.ts
+++ b/e2e/scfz-theme.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { $, file, spawn } from "bun";
+import { createWorkspaceFromCLI } from "../test/workspace";
+
+const TMP_FOLDER = process.env.TMP_FOLDER || "/tmp";
+
+describe("e2e: theme command", () => {
+    const folder = join(
+        TMP_FOLDER,
+        `test-${(1000 + Math.ceil(Math.random() * 1000)).toString(16)}`,
+    );
+
+    afterAll(async () => {
+        await $`rm -rf ${folder}`;
+    });
+
+    test("@smoke: should add a theme with correct indentation", async () => {
+        await createWorkspaceFromCLI(folder, "landscape");
+
+        const proc = spawn([
+            "dist/scfz",
+            "theme",
+            "--dest",
+            folder,
+            "--themeAction",
+            "Add themes",
+            "--additionalThemes",
+            "https://formulamonks.github.io/scaffoldizr/assets/scaffoldizr-default.json",
+        ]);
+
+        await proc.exited;
+        expect(proc.exitCode).toBe(0);
+
+        const workspaceContents = await file(
+            `${folder}/architecture/workspace.dsl`,
+        ).text();
+        expect(workspaceContents).toMatch(/^        themes /m);
+    });
+});

--- a/lib/generators/theme.ts
+++ b/lib/generators/theme.ts
@@ -14,6 +14,7 @@ import { BUILTIN_THEMES, COLOR_THEME_URLS } from "../utils/themes";
 type ThemeAnswers = {
     selectedThemes: string[];
     hasExistingThemesLine: boolean;
+    needsIndent: boolean;
 };
 
 const generator: GeneratorDefinition<ThemeAnswers> = {
@@ -43,7 +44,11 @@ const generator: GeneratorDefinition<ThemeAnswers> = {
                 }
             }
 
-            return { selectedThemes: [], hasExistingThemesLine: false };
+            return {
+                selectedThemes: [],
+                hasExistingThemesLine: false,
+                needsIndent: true,
+            };
         }
 
         if (themeAction === "Add themes") {
@@ -111,6 +116,7 @@ const generator: GeneratorDefinition<ThemeAnswers> = {
             return {
                 selectedThemes: finalSelectedThemes,
                 hasExistingThemesLine,
+                needsIndent: !hasExistingThemesLine,
             };
         }
 
@@ -118,7 +124,11 @@ const generator: GeneratorDefinition<ThemeAnswers> = {
 
         if (currentThemes.length === 0) {
             console.log("No themes configured in workspace.dsl");
-            return { selectedThemes: [], hasExistingThemesLine: false };
+            return {
+                selectedThemes: [],
+                hasExistingThemesLine: false,
+                needsIndent: true,
+            };
         }
 
         const themesToRemove = await checkbox({
@@ -148,10 +158,18 @@ const generator: GeneratorDefinition<ThemeAnswers> = {
             );
             await write(workspaceDslPath, cleaned);
             console.log("All themes removed from workspace.dsl");
-            return { selectedThemes: [], hasExistingThemesLine: false };
+            return {
+                selectedThemes: [],
+                hasExistingThemesLine: false,
+                needsIndent: false,
+            };
         }
 
-        return { selectedThemes, hasExistingThemesLine: true };
+        return {
+            selectedThemes,
+            hasExistingThemesLine: true,
+            needsIndent: false,
+        };
     },
     actions: [
         {

--- a/lib/templates/theme.hbs
+++ b/lib/templates/theme.hbs
@@ -1,1 +1,1 @@
-themes{{#each selectedThemes}} "{{this}}"{{/each}}
+{{#if needsIndent}}        {{/if}}themes{{#each selectedThemes}} "{{this}}"{{/each}}


### PR DESCRIPTION
Fixes #243

When \`scfz theme\` appended a new \`themes\` line to a workspace that had no existing themes, the line was inserted at column 0 (no indentation), breaking the standard 4-space formatting used inside \`views {}\` blocks.

The fix passes a \`needsIndent\` boolean through the generator answers so the Handlebars template can conditionally prepend 4 spaces.