### PR TITLE
fix(update): await refreshUpdateCache to ensure cache is written before returning

### DIFF
--- a/lib/utils/update.ts
+++ b/lib/utils/update.ts
@@ -145,6 +145,6 @@ export async function checkUpdate(
         }
     }
 
-    void refreshUpdateCache(cacheFilePath);
+    await refreshUpdateCache(cacheFilePath);
     return null;
 }


### PR DESCRIPTION
## Summary

- Changed `void refreshUpdateCache(cacheFilePath)` to `await refreshUpdateCache(cacheFilePath)` in `checkUpdate`
- Ensures the update cache is fully written before the function returns, preventing potential race conditions where the cache might not be persisted on fast exits