### PR TITLE
feat(utils): extract fetchLatestVersion with force-bypass from update.ts

### DIFF
--- a/lib/utils/update.test.ts
+++ b/lib/utils/update.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import * as operatingSystem from "node:os";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { checkUpdate } from "./update";
+import { checkUpdate, fetchLatestVersion } from "./update";
 
 const UPDATE_CACHE_FILE = ".scaffoldizr-update.json";
 const UPDATE_CHECK_WINDOW = 86_400_000;
@@ -192,6 +192,114 @@ describe("checkUpdate", () => {
             const updateMessage = await checkUpdate("0.9.3");
 
             expect(updateMessage).toBeNull();
+        });
+    });
+});
+
+describe("fetchLatestVersion", () => {
+    beforeEach(async () => {
+        temporaryHomeDirectory = await mkdtemp(
+            join(tmpdir(), "scaffoldizr-update-test-"),
+        );
+        originalFetch = globalThis.fetch;
+        homedirSpy = spyOn(operatingSystem, "homedir").mockReturnValue(
+            temporaryHomeDirectory,
+        );
+        globalThis.fetch = ((..._args: Parameters<typeof globalThis.fetch>) =>
+            Promise.resolve(
+                new Response(null, { status: 500 }),
+            )) as unknown as typeof globalThis.fetch;
+    });
+
+    afterEach(async () => {
+        globalThis.fetch = originalFetch;
+        homedirSpy.mockRestore();
+        await rm(temporaryHomeDirectory, { recursive: true, force: true });
+    });
+
+    describe("force=false (default)", () => {
+        it("returns cached version when cache is fresh", async () => {
+            await writeUpdateCacheFile("1.5.0");
+
+            const version = await fetchLatestVersion();
+
+            expect(version).toBe("1.5.0");
+        });
+
+        it("returns null when cache is stale", async () => {
+            await writeUpdateCacheFile(
+                "1.5.0",
+                Date.now() - UPDATE_CHECK_WINDOW - 3_600_000,
+            );
+
+            const version = await fetchLatestVersion();
+
+            expect(version).toBeNull();
+        });
+
+        it("returns null when cache is missing", async () => {
+            const version = await fetchLatestVersion();
+
+            expect(version).toBeNull();
+        });
+    });
+
+    describe("force=true", () => {
+        it("returns version from successful GitHub fetch", async () => {
+            globalThis.fetch = ((
+                ..._args: Parameters<typeof globalThis.fetch>
+            ) =>
+                Promise.resolve(
+                    new Response(JSON.stringify({ tag_name: "v2.5.0" }), {
+                        status: 200,
+                    }),
+                )) as unknown as typeof globalThis.fetch;
+
+            const version = await fetchLatestVersion(true);
+
+            expect(version).toBe("2.5.0");
+        });
+
+        it("writes fetched version to cache file", async () => {
+            globalThis.fetch = ((
+                ..._args: Parameters<typeof globalThis.fetch>
+            ) =>
+                Promise.resolve(
+                    new Response(JSON.stringify({ tag_name: "v2.5.0" }), {
+                        status: 200,
+                    }),
+                )) as unknown as typeof globalThis.fetch;
+
+            await fetchLatestVersion(true);
+
+            const cacheContent = await readFile(
+                join(temporaryHomeDirectory, UPDATE_CACHE_FILE),
+                "utf8",
+            );
+            const cache = JSON.parse(cacheContent) as { latestVersion: string };
+            expect(cache.latestVersion).toBe("2.5.0");
+        });
+
+        it("returns null when GitHub fetch fails", async () => {
+            const version = await fetchLatestVersion(true);
+
+            expect(version).toBeNull();
+        });
+
+        it("ignores fresh cache and fetches from GitHub", async () => {
+            await writeUpdateCacheFile("1.0.0");
+            globalThis.fetch = ((
+                ..._args: Parameters<typeof globalThis.fetch>
+            ) =>
+                Promise.resolve(
+                    new Response(JSON.stringify({ tag_name: "v2.5.0" }), {
+                        status: 200,
+                    }),
+                )) as unknown as typeof globalThis.fetch;
+
+            const version = await fetchLatestVersion(true);
+
+            expect(version).toBe("2.5.0");
         });
     });
 });

--- a/lib/utils/update.test.ts
+++ b/lib/utils/update.test.ts
@@ -226,6 +226,14 @@ describe("fetchLatestVersion", () => {
             expect(version).toBe("1.5.0");
         });
 
+        it("normalizes cached version by stripping v prefix", async () => {
+            await writeUpdateCacheFile("v1.5.0");
+
+            const version = await fetchLatestVersion();
+
+            expect(version).toBe("1.5.0");
+        });
+
         it("returns null when cache is stale", async () => {
             await writeUpdateCacheFile(
                 "1.5.0",

--- a/lib/utils/update.ts
+++ b/lib/utils/update.ts
@@ -122,10 +122,10 @@ export async function fetchLatestVersion(
             const cacheIsFresh =
                 Date.now() - cachedUpdate.checkedAt < UPDATE_CHECK_WINDOW;
             if (cacheIsFresh) {
-                return cachedUpdate.latestVersion;
+                return stripVersionPrefix(cachedUpdate.latestVersion);
             }
         }
-        await refreshUpdateCache(cacheFilePath);
+        void refreshUpdateCache(cacheFilePath);
         return null;
     }
 

--- a/lib/utils/update.ts
+++ b/lib/utils/update.ts
@@ -73,7 +73,9 @@ async function readUpdateCache(
     }
 }
 
-async function refreshUpdateCache(cacheFilePath: string): Promise<void> {
+async function refreshUpdateCache(
+    cacheFilePath: string,
+): Promise<string | null> {
     try {
         const latestReleaseResponse = await fetch(LATEST_RELEASE_URL, {
             headers: {
@@ -85,7 +87,7 @@ async function refreshUpdateCache(cacheFilePath: string): Promise<void> {
         });
 
         if (!latestReleaseResponse.ok) {
-            return;
+            return null;
         }
 
         const releasePayload = (await latestReleaseResponse.json()) as {
@@ -93,16 +95,41 @@ async function refreshUpdateCache(cacheFilePath: string): Promise<void> {
         };
 
         if (typeof releasePayload.tag_name !== "string") {
-            return;
+            return null;
         }
 
+        const version = stripVersionPrefix(releasePayload.tag_name);
         const cachePayload: UpdateCache = {
-            latestVersion: stripVersionPrefix(releasePayload.tag_name),
+            latestVersion: version,
             checkedAt: Date.now(),
         };
 
         await write(cacheFilePath, JSON.stringify(cachePayload));
-    } catch {}
+        return version;
+    } catch {
+        return null;
+    }
+}
+
+export async function fetchLatestVersion(
+    force = false,
+): Promise<string | null> {
+    const cacheFilePath = join(homedir(), UPDATE_CACHE_FILE);
+
+    if (!force) {
+        const cachedUpdate = await readUpdateCache(cacheFilePath);
+        if (cachedUpdate) {
+            const cacheIsFresh =
+                Date.now() - cachedUpdate.checkedAt < UPDATE_CHECK_WINDOW;
+            if (cacheIsFresh) {
+                return cachedUpdate.latestVersion;
+            }
+        }
+        await refreshUpdateCache(cacheFilePath);
+        return null;
+    }
+
+    return refreshUpdateCache(cacheFilePath);
 }
 
 export async function checkUpdate(
@@ -116,35 +143,21 @@ export async function checkUpdate(
         return null;
     }
 
-    const cacheFilePath = join(homedir(), UPDATE_CACHE_FILE);
-    const cachedUpdate = await readUpdateCache(cacheFilePath);
+    const latestVersion = await fetchLatestVersion(false);
 
-    if (cachedUpdate) {
-        const cacheIsFresh =
-            Date.now() - cachedUpdate.checkedAt < UPDATE_CHECK_WINDOW;
-
-        if (cacheIsFresh) {
-            const normalizedCurrentVersion = stripVersionPrefix(currentVersion);
-            const normalizedLatestVersion = stripVersionPrefix(
-                cachedUpdate.latestVersion,
-            );
-
-            if (
-                isNewerVersion(
-                    normalizedLatestVersion,
-                    normalizedCurrentVersion,
-                )
-            ) {
-                return buildUpdateNotification(
-                    normalizedCurrentVersion,
-                    normalizedLatestVersion,
-                );
-            }
-
-            return null;
-        }
+    if (!latestVersion) {
+        return null;
     }
 
-    await refreshUpdateCache(cacheFilePath);
+    const normalizedCurrentVersion = stripVersionPrefix(currentVersion);
+    const normalizedLatestVersion = stripVersionPrefix(latestVersion);
+
+    if (isNewerVersion(normalizedLatestVersion, normalizedCurrentVersion)) {
+        return buildUpdateNotification(
+            normalizedCurrentVersion,
+            normalizedLatestVersion,
+        );
+    }
+
     return null;
 }


### PR DESCRIPTION
## Summary

- Extracted `fetchLatestVersion(force = false)` as a new exported function from `lib/utils/update.ts`
- Modified `refreshUpdateCache` to return the fetched version string (`string | null`) instead of `void`
- Refactored `checkUpdate` to use `fetchLatestVersion(false)` internally, preserving the existing 24-hour cache behavior

When `force=false` (default), the function returns the cached version if it is fresh (within 24h), otherwise triggers a background refresh and returns `null`. When `force=true`, it bypasses the cache and always fetches fresh from GitHub.

Closes #267