### PR TITLE
feat: add scfz update command

### DIFF
--- a/e2e/scfz-update.test.ts
+++ b/e2e/scfz-update.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { spawn } from "bun";
+
+describe("e2e: scfz update", () => {
+    test("should report up-to-date when versions match", async () => {
+        const currentVersion = process.env.TESTED_VERSION as string;
+        const proc = spawn(["dist/scfz", "update"], {
+            env: {
+                ...process.env,
+                SCFZ_FORCE_UPDATE_VERSION: currentVersion,
+            },
+        });
+
+        const stdout = await new Response(proc.stdout).text();
+        await proc.exited;
+
+        expect(proc.exitCode).toBe(0);
+        expect(stdout).toContain("already up to date");
+    });
+
+    test("should announce update without running installer in test mode", async () => {
+        const proc = spawn(["dist/scfz", "update"], {
+            env: {
+                ...process.env,
+                SCFZ_FORCE_UPDATE_VERSION: "v999.999.999",
+                SCFZ_SKIP_UPDATE_INSTALL: "1",
+            },
+        });
+
+        const stdout = await new Response(proc.stdout).text();
+        await proc.exited;
+
+        expect(proc.exitCode).toBe(0);
+        expect(stdout).toContain("Updating scfz from");
+        expect(stdout).toContain("Skipping install script in test mode.");
+    });
+});

--- a/e2e/scfz-update.test.ts
+++ b/e2e/scfz-update.test.ts
@@ -3,6 +3,7 @@ import { spawn } from "bun";
 
 describe("e2e: scfz update", () => {
     test("should report up-to-date when versions match", async () => {
+        expect(process.env.TESTED_VERSION).toBeDefined();
         const currentVersion = process.env.TESTED_VERSION as string;
         const proc = spawn(["dist/scfz", "update"], {
             env: {

--- a/lib/commands/update.ts
+++ b/lib/commands/update.ts
@@ -1,0 +1,52 @@
+import { $ } from "bun";
+import chalk from "chalk";
+import { fetchLatestVersion } from "../utils/update";
+import { isNewerVersion, stripVersionPrefix } from "../utils/version";
+
+export async function runUpdate(currentVersion: string): Promise<void> {
+    const latestVersion =
+        process.env.SCFZ_FORCE_UPDATE_FETCH_FAIL !== undefined
+            ? null
+            : process.env.SCFZ_FORCE_UPDATE_VERSION?.trim() ||
+              (await fetchLatestVersion(true));
+
+    if (!latestVersion) {
+        console.error(
+            chalk.red("[ERROR]: Unable to fetch the latest scfz version."),
+        );
+        process.exit(1);
+    }
+
+    const normalizedCurrentVersion = stripVersionPrefix(currentVersion);
+    const normalizedLatestVersion = stripVersionPrefix(latestVersion);
+
+    if (!isNewerVersion(normalizedLatestVersion, normalizedCurrentVersion)) {
+        console.log(
+            chalk.green(
+                `scfz is already up to date (v${normalizedCurrentVersion}).`,
+            ),
+        );
+        return;
+    }
+
+    console.log(
+        chalk.yellow(
+            `Updating scfz from ${normalizedCurrentVersion} to ${normalizedLatestVersion}...`,
+        ),
+    );
+
+    if (process.env.SCFZ_SKIP_UPDATE_INSTALL !== undefined) {
+        console.log(chalk.yellow("Skipping install script in test mode."));
+        return;
+    }
+
+    try {
+        await $`curl -s https://formulamonks.github.io/scaffoldizr/assets/install.sh | sh`;
+        console.log(
+            chalk.green(`scfz updated to v${normalizedLatestVersion}.`),
+        );
+    } catch {
+        console.error(chalk.red("[ERROR]: Failed to update scfz."));
+        process.exit(1);
+    }
+}

--- a/lib/commands/update.ts
+++ b/lib/commands/update.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import chalk from "chalk";
-import { fetchLatestVersion } from "../utils/update";
+import { fetchLatestVersion, INSTALL_SCRIPT_URL } from "../utils/update";
 import { isNewerVersion, stripVersionPrefix } from "../utils/version";
 
 export async function runUpdate(currentVersion: string): Promise<void> {
@@ -23,7 +23,7 @@ export async function runUpdate(currentVersion: string): Promise<void> {
     if (!isNewerVersion(normalizedLatestVersion, normalizedCurrentVersion)) {
         console.log(
             chalk.green(
-                `scfz is already up to date (v${normalizedCurrentVersion}).`,
+                `scfz is already up to date (${normalizedCurrentVersion}).`,
             ),
         );
         return;
@@ -41,10 +41,8 @@ export async function runUpdate(currentVersion: string): Promise<void> {
     }
 
     try {
-        await $`curl -s https://formulamonks.github.io/scaffoldizr/assets/install.sh | sh`;
-        console.log(
-            chalk.green(`scfz updated to v${normalizedLatestVersion}.`),
-        );
+        await $`curl -s ${INSTALL_SCRIPT_URL} | sh`;
+        console.log(chalk.green(`scfz updated to ${normalizedLatestVersion}.`));
     } catch {
         console.error(chalk.red("[ERROR]: Failed to update scfz."));
         process.exit(1);

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -48,6 +48,12 @@ Create a Structurizr DSL scaffolding in seconds!
     `),
     );
 
+    if (args._?.[0]?.toString() === "update") {
+        const { runUpdate } = await import("./commands/update");
+        await runUpdate(scfzVersion);
+        process.exit(0);
+    }
+
     const destPath = resolve(process.cwd(), args.dest);
     const workspacePath = getWorkspacePath(destPath);
 

--- a/lib/utils/update.test.ts
+++ b/lib/utils/update.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import * as operatingSystem from "node:os";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { checkUpdate, fetchLatestVersion } from "./update";
+import { checkUpdate, fetchLatestVersion, INSTALL_SCRIPT_URL } from "./update";
 
 const UPDATE_CACHE_FILE = ".scaffoldizr-update.json";
 const UPDATE_CHECK_WINDOW = 86_400_000;
@@ -192,6 +192,60 @@ describe("checkUpdate", () => {
             const updateMessage = await checkUpdate("0.9.3");
 
             expect(updateMessage).toBeNull();
+        });
+    });
+
+    describe("banner content", () => {
+        const stripAnsi = (text: string) =>
+            text.replace(
+                new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"),
+                "",
+            );
+
+        it("includes the full install script URL in the notification", async () => {
+            await writeUpdateCacheFile("2.0.0");
+
+            const updateMessage = await checkUpdate("1.0.0");
+
+            expect(updateMessage).toContain(`curl -s ${INSTALL_SCRIPT_URL}`);
+        });
+
+        it("renders the curl command and pipe operator on separate lines", async () => {
+            await writeUpdateCacheFile("2.0.0");
+
+            const updateMessage = await checkUpdate("1.0.0");
+
+            expect(updateMessage).toBeString();
+            const plainLines = stripAnsi(updateMessage as string)
+                .split("\n")
+                .map((line) => line.trim())
+                .filter(Boolean);
+
+            const curlLineIndex = plainLines.findIndex((line) =>
+                line.includes(`curl -s ${INSTALL_SCRIPT_URL}`),
+            );
+            const pipeLineIndex = plainLines.findIndex((line) =>
+                line.includes("| sh"),
+            );
+
+            expect(curlLineIndex).toBeGreaterThanOrEqual(0);
+            expect(pipeLineIndex).toBeGreaterThanOrEqual(0);
+            expect(plainLines[curlLineIndex]).not.toContain("| sh");
+            expect(pipeLineIndex).not.toBe(curlLineIndex);
+        });
+
+        it("does not duplicate the install script path in the banner", async () => {
+            await writeUpdateCacheFile("2.0.0");
+
+            const updateMessage = await checkUpdate("1.0.0");
+
+            expect(updateMessage).toBeString();
+            const plainText = stripAnsi(updateMessage as string);
+            const pathMatches = plainText.match(
+                /formulamonks\.github\.io\/scaffoldizr\/assets\/install\.sh/g,
+            );
+
+            expect(pathMatches).toHaveLength(1);
         });
     });
 });

--- a/lib/utils/update.ts
+++ b/lib/utils/update.ts
@@ -15,12 +15,15 @@ const UPDATE_CHECK_WINDOW = 86_400_000;
 const LATEST_RELEASE_URL =
     "https://api.github.com/repos/FormulaMonks/scaffoldizr/releases/latest";
 
+export const INSTALL_SCRIPT_URL =
+    "https://formulamonks.github.io/scaffoldizr/assets/install.sh";
+
 function buildUpdateNotification(
     currentVersion: string,
     latestVersion: string,
 ): string {
     const versionText = `Update available: ${currentVersion} → ${latestVersion}`;
-    const curlLine1 = "curl -s https://formulamonks.github.io/";
+    const curlLine1 = `curl -s ${INSTALL_SCRIPT_URL}`;
     const curlLine2 = "scaffoldizr/assets/install.sh | sh";
     const runToUpdateText = "Run to update:";
 

--- a/lib/utils/update.ts
+++ b/lib/utils/update.ts
@@ -24,7 +24,7 @@ function buildUpdateNotification(
 ): string {
     const versionText = `Update available: ${currentVersion} → ${latestVersion}`;
     const curlLine1 = `curl -s ${INSTALL_SCRIPT_URL}`;
-    const curlLine2 = "scaffoldizr/assets/install.sh | sh";
+    const curlLine2 = "| sh";
     const runToUpdateText = "Run to update:";
 
     const innerWidth = Math.max(


### PR DESCRIPTION
## Summary

- Adds `lib/commands/update.ts` with `runUpdate()` that fetches the latest version from GitHub (bypassing cache via `fetchLatestVersion(true)`), prints an up-to-date message or runs the install script via Bun `$`
- Wires `scfz update` as a subcommand in `lib/main.ts` before workspace resolution, so it works without an existing workspace
- Adds `e2e/scfz-update.test.ts` covering both the "already up to date" and "update available" scenarios using test-mode env vars (`SCFZ_FORCE_UPDATE_VERSION`, `SCFZ_SKIP_UPDATE_INSTALL`)

Closes #268