### PR TITLE
chore: update bun version and Structurizr base version

### DIFF
--- a/.agents/skills/scaffoldizr/extra/CLI.md
+++ b/.agents/skills/scaffoldizr/extra/CLI.md
@@ -15,10 +15,10 @@ Refer to the [Structurizr commands reference](https://docs.structurizr.com/comma
 ./architecture/scripts/export.ps1
 ```
 
-Or run the Docker command directly (replace `2026.03.06` with `$STCTZR_VERSION` if you need a different version):
+Or run the Docker command directly (replace `2026.05.22` with `$STCTZR_VERSION` if you need a different version):
 
 ```bash
-docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.03.06 export -w /usr/local/structurizr/workspace.dsl -f json
+docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.05.22 export -w /usr/local/structurizr/workspace.dsl -f json
 ```
 
 ## List elements within a workspace
@@ -26,7 +26,7 @@ docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structur
 You can list all the elements within a Structurizr workspace by running the following command from the workspace root (the folder containing `workspace.dsl`):
 
 ```bash
-docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.03.06 list -w /usr/local/structurizr/workspace.dsl
+docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.05.22 list -w /usr/local/structurizr/workspace.dsl
 ```
 
 The command will output the current elements in the following format:
@@ -43,7 +43,7 @@ The command will output the current elements in the following format:
 Whenever changes are made to the DSL files, it's important to validate that the workspace is still valid and there are no errors. To do so, run the following command:
 
 ```bash
-docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.03.06 validate -w /usr/local/structurizr/workspace.dsl
+docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.05.22 validate -w /usr/local/structurizr/workspace.dsl
 ```
 
 ### Inspect violations
@@ -51,5 +51,5 @@ docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structur
 The inspect command allows you to inspect a JSON/DSL workspace via the workspace inspection feature. The return code indicates the number of violations that were shown. To run the inspect command:
 
 ```bash
-docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.03.06 inspect -w /usr/local/structurizr/workspace.dsl
+docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.05.22 inspect -w /usr/local/structurizr/workspace.dsl
 ```

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,8 +1,7 @@
 [tools]
 jq = "1.7.1"
 ruby = "3.3"
-java = "23"
-bun = "1.3.3"
+bun = "1.3.14"
 
 [tasks."docs:install"]
 run = "cd docs && bundle"

--- a/architecture/scripts/export.ps1
+++ b/architecture/scripts/export.ps1
@@ -1,5 +1,5 @@
 $docsLocation = Split-Path -Parent $PSScriptRoot
-$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.03.06" }
+$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.05.22" }
 
 Write-Host "Exporting workspace: $docsLocation (structurizr:${version})"
 

--- a/architecture/scripts/export.sh
+++ b/architecture/scripts/export.sh
@@ -2,7 +2,7 @@
 
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 version="${STCTZR_VERSION:-}"
-if [ -z "$version" ]; then version="2026.03.06"; fi
+if [ -z "$version" ]; then version="2026.05.22"; fi
 
 echo "Exporting workspace: ${docs_location} (structurizr:${version})"
 

--- a/architecture/scripts/inspect.ps1
+++ b/architecture/scripts/inspect.ps1
@@ -1,5 +1,5 @@
 $docsLocation = Split-Path -Parent $PSScriptRoot
-$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.03.06" }
+$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.05.22" }
 
 Write-Host "Inspecting workspace: $docsLocation (structurizr:${version})"
 

--- a/architecture/scripts/inspect.sh
+++ b/architecture/scripts/inspect.sh
@@ -2,7 +2,7 @@
 
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 version="${STCTZR_VERSION:-}"
-if [ -z "$version" ]; then version="2026.03.06"; fi
+if [ -z "$version" ]; then version="2026.05.22"; fi
 
 echo "Inspecting workspace: ${docs_location} (structurizr:${version})"
 

--- a/architecture/scripts/run.ps1
+++ b/architecture/scripts/run.ps1
@@ -1,6 +1,6 @@
 $docsLocation = Split-Path -Parent $PSScriptRoot
 $port = if ($args[0]) { $args[0] } else { 8080 }
-$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.03.06" }
+$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.05.22" }
 
 if (-not (Test-Path "$docsLocation\workspace.dsl")) {
     Write-Error "ERROR: workspace.dsl file not found in `"$docsLocation`" folder."

--- a/architecture/scripts/run.sh
+++ b/architecture/scripts/run.sh
@@ -3,7 +3,7 @@
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 port=${1:-8080}
 version="${STCTZR_VERSION:-}"
-if [ -z "$version" ]; then version="2026.03.06"; fi
+if [ -z "$version" ]; then version="2026.05.22"; fi
 
 # Check if workspace.dsl file exists
 if [ ! -e "${docs_location}/workspace.dsl" ]; then

--- a/architecture/scripts/update.ps1
+++ b/architecture/scripts/update.ps1
@@ -1,7 +1,7 @@
 $docsLocation = Split-Path -Parent $PSScriptRoot
 
 Write-Host "Updating workspace: $docsLocation"
-$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.03.06" }
+$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.05.22" }
 
 if (-not (Test-Path "$docsLocation\workspace.json")) {
     Write-Error "ERROR: workspace.json file not found in `"$docsLocation`" folder."

--- a/architecture/scripts/update.sh
+++ b/architecture/scripts/update.sh
@@ -3,7 +3,7 @@
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 echo "Updating workspace: ${docs_location}"
 version="${STCTZR_VERSION:-}"
-if [ -z "$version" ]; then version="2026.03.06"; fi
+if [ -z "$version" ]; then version="2026.05.22"; fi
 
 if [ ! -e "${docs_location}/workspace.json" ]; then
     echo "ERROR: workspace.json file not found in \"${docs_location}\" folder.";

--- a/lib/utils/structurizr-version.ts
+++ b/lib/utils/structurizr-version.ts
@@ -1,4 +1,4 @@
-export const STRUCTURIZR_LOCKED_VERSION = "2026.03.06";
+export const STRUCTURIZR_LOCKED_VERSION = "2026.05.22";
 
 export const structurizrVersion =
     process.env.STCTZR_VERSION ?? STRUCTURIZR_LOCKED_VERSION;


### PR DESCRIPTION
## Summary

- Updates Bun version to 1.3.14
- Updates Structurizr base version to 2026.05.22

## Changes

- Updated `.mise.toml` with new Bun version
- Updated all architecture scripts (run, export, inspect, update) with new Structurizr version
- Updated `lib/utils/structurizr-version.ts`
- Updated Scaffoldizr skill documentation