### PR TITLE
fix(prompts): skip optional input prompts in non-interactive mode

### DIFF
--- a/.agents/skills/scaffoldizr/SKILL.md
+++ b/.agents/skills/scaffoldizr/SKILL.md
@@ -82,7 +82,7 @@ All prompt questions can be answered via CLI flags using `--parameter "value"` o
 | `external-system` | `--elementName`, `--extSystemDescription` |
 | `view` | `--viewType`, `--viewName`, `--viewDescription` |
 | `constant` | `--constantName`, `--constantValue` |
-| `archetype` | `--archetypeName`, `--archetypeDescription` |
+| `archetype` | `--archetypeName`, `--archetypeBaseType`, `--archetypeDescription` (optional), `--archetypeTechnology` (optional), `--archetypeTags` (optional) |
 | `theme` | `--themeAction "Add themes" --additionalThemes "<url1>,<url2>"` |
 
 Each element file documents the specific flags and CLI command for that generator.

--- a/.agents/skills/scaffoldizr/references/archetype.md
+++ b/.agents/skills/scaffoldizr/references/archetype.md
@@ -46,8 +46,18 @@ Refer to the [documentation](https://docs.structurizr.com/dsl/archetypes) for fu
 ```bash
 scfz archetype \
   --archetypeName "<archetype name>" \
-  --archetypeDescription "<description>"
+  --archetypeBaseType "<relationship|system|container|component>"
 ```
+
+Optional flags (omit to leave empty):
+
+| Flag | Description |
+|---|---|
+| `--archetypeDescription` | Description of the archetype |
+| `--archetypeTechnology` | Technology (not available for `system` base type) |
+| `--archetypeTags` | Comma-separated tags |
+
+> **Note**: When running non-interactively (any CLI flags present), optional fields that are not provided are automatically skipped — no interactive prompt will appear.
 
 ## References
 

--- a/e2e/scfz-non-interactive.test.ts
+++ b/e2e/scfz-non-interactive.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $, file, spawn } from "bun";
@@ -177,6 +177,75 @@ describe("e2e: non-interactive subcommands (softwaresystem)", () => {
         expect(elementContents).toContain(
             'NiContainer = container "NI Container"',
         );
+    });
+});
+
+describe("e2e: non-interactive archetype subcommand", () => {
+    const folder = join(
+        TMP_FOLDER,
+        `test-${(1000 + Math.ceil(Math.random() * 1000)).toString(16)}`,
+    );
+
+    beforeAll(async () => {
+        await createWorkspaceFromCLI(folder, "softwaresystem");
+    });
+
+    afterAll(async () => {
+        await $`rm -rf ${folder}`;
+    });
+
+    test("should add a relationship archetype non-interactively without optional fields", async () => {
+        const proc = spawn([
+            "dist/scfz",
+            "archetype",
+            "--dest",
+            folder,
+            "--archetypeName",
+            "HTTPS",
+            "--archetypeBaseType",
+            "relationship",
+        ]);
+
+        await proc.exited;
+        expect(proc.exitCode).toBe(0);
+
+        const archetypeFileExists = await file(
+            `${folder}/architecture/archetypes/1_https_relationship.dsl`,
+        ).exists();
+        expect(archetypeFileExists).toBe(true);
+
+        const elementContents = await file(
+            `${folder}/architecture/archetypes/1_https_relationship.dsl`,
+        ).text();
+        expect(elementContents).toContain("https = -> {");
+        expect(elementContents).not.toContain("description");
+        expect(elementContents).not.toContain("technology");
+    });
+
+    test("should add a relationship archetype non-interactively with optional description", async () => {
+        const proc = spawn([
+            "dist/scfz",
+            "archetype",
+            "--dest",
+            folder,
+            "--archetypeName",
+            "GRPC",
+            "--archetypeBaseType",
+            "relationship",
+            "--archetypeDescription",
+            "gRPC protocol",
+            "--archetypeTechnology",
+            "gRPC",
+        ]);
+
+        await proc.exited;
+        expect(proc.exitCode).toBe(0);
+
+        const elementContents = await file(
+            `${folder}/architecture/archetypes/2_grpc_relationship.dsl`,
+        ).text();
+        expect(elementContents).toContain('description "gRPC protocol"');
+        expect(elementContents).toContain('technology "gRPC"');
     });
 });
 

--- a/lib/utils/prompts.test.ts
+++ b/lib/utils/prompts.test.ts
@@ -101,6 +101,80 @@ describe("prompts", () => {
             inputSpy.mockRestore();
         });
 
+        test("skips prompt and returns empty string for optional field in non-interactive mode", async () => {
+            process.argv = ["bun", "scfz", "--archetypeName=test"];
+
+            const { resetArgvCache, input } = await import("./prompts");
+            resetArgvCache();
+
+            const result = await input({
+                message: "Description (optional):",
+                name: "archetypeDescription",
+            });
+
+            expect(result).toBe("");
+        });
+
+        test("skips prompt and returns default value for optional field in non-interactive mode", async () => {
+            process.argv = ["bun", "scfz", "--archetypeName=test"];
+
+            const { resetArgvCache, input } = await import("./prompts");
+            resetArgvCache();
+
+            const result = await input({
+                message: "Description (optional):",
+                name: "archetypeDescription",
+                default: "default-value",
+            });
+
+            expect(result).toBe("default-value");
+        });
+
+        test("still prompts for optional field when no CLI args present", async () => {
+            process.argv = ["bun", "scfz"];
+
+            const inquirerPrompts = await import("@inquirer/prompts");
+            const inputSpy = spyOn(inquirerPrompts, "input").mockResolvedValue(
+                "UserTyped",
+            );
+
+            const { resetArgvCache, input } = await import("./prompts");
+            resetArgvCache();
+
+            const result = await input({
+                message: "Description (optional):",
+                name: "archetypeDescription",
+            });
+
+            expect(result).toBe("UserTyped");
+            expect(inputSpy).toHaveBeenCalled();
+
+            inputSpy.mockRestore();
+        });
+
+        test("still prompts for required field even in non-interactive mode when not provided", async () => {
+            process.argv = ["bun", "scfz", "--archetypeBaseType=relationship"];
+
+            const inquirerPrompts = await import("@inquirer/prompts");
+            const inputSpy = spyOn(inquirerPrompts, "input").mockResolvedValue(
+                "UserTyped",
+            );
+
+            const { resetArgvCache, input } = await import("./prompts");
+            resetArgvCache();
+
+            const result = await input({
+                message: "Archetype name:",
+                name: "archetypeName",
+                required: true,
+            });
+
+            expect(result).toBe("UserTyped");
+            expect(inputSpy).toHaveBeenCalled();
+
+            inputSpy.mockRestore();
+        });
+
         test("falls back to interactive when no name provided in config", async () => {
             process.argv = ["bun", "scfz", "--workspaceName=MyWorkspace"];
 

--- a/lib/utils/prompts.test.ts
+++ b/lib/utils/prompts.test.ts
@@ -175,6 +175,30 @@ describe("prompts", () => {
             inputSpy.mockRestore();
         });
 
+        test("still prompts for field with validate in non-interactive mode when not provided", async () => {
+            process.argv = ["bun", "scfz", "--archetypeBaseType=relationship"];
+
+            const inquirerPrompts = await import("@inquirer/prompts");
+            const inputSpy = spyOn(inquirerPrompts, "input").mockResolvedValue(
+                "UserTyped",
+            );
+
+            const { resetArgvCache, input } = await import("./prompts");
+            resetArgvCache();
+
+            const result = await input({
+                message: "System name:",
+                name: "systemName",
+                validate: (value: string) =>
+                    value.length > 0 ? true : "Required",
+            });
+
+            expect(result).toBe("UserTyped");
+            expect(inputSpy).toHaveBeenCalled();
+
+            inputSpy.mockRestore();
+        });
+
         test("falls back to interactive when no name provided in config", async () => {
             process.argv = ["bun", "scfz", "--workspaceName=MyWorkspace"];
 

--- a/lib/utils/prompts.ts
+++ b/lib/utils/prompts.ts
@@ -85,6 +85,10 @@ function getCliValue(name: string | undefined): string | undefined {
     return parseArgv()[name];
 }
 
+function isNonInteractiveMode(): boolean {
+    return Object.keys(parseArgv()).length > 0;
+}
+
 async function runValidation(
     value: string,
     validate: (value: string) => ValidateResult,
@@ -103,13 +107,18 @@ export async function input(
     const { name, ...rest } = config;
 
     const cliValue = getCliValue(name);
-    if (cliValue === undefined)
-        return inquirerInput(rest as Parameters<typeof inquirerInput>[0]);
-
-    if (rest.validate !== undefined) {
-        await runValidation(cliValue, rest.validate);
+    if (cliValue !== undefined) {
+        if (rest.validate !== undefined) {
+            await runValidation(cliValue, rest.validate);
+        }
+        return cliValue;
     }
-    return cliValue;
+
+    if (!rest.required && name !== undefined && isNonInteractiveMode()) {
+        return rest.default ?? "";
+    }
+
+    return inquirerInput(rest as Parameters<typeof inquirerInput>[0]);
 }
 
 export async function select<Value>(

--- a/lib/utils/prompts.ts
+++ b/lib/utils/prompts.ts
@@ -126,7 +126,12 @@ export async function input(
         return cliValue;
     }
 
-    if (!rest.required && name !== undefined && isNonInteractiveMode()) {
+    if (
+        !rest.required &&
+        rest.validate === undefined &&
+        name !== undefined &&
+        isNonInteractiveMode()
+    ) {
         return rest.default ?? "";
     }
 

--- a/lib/utils/prompts.ts
+++ b/lib/utils/prompts.ts
@@ -85,8 +85,20 @@ function getCliValue(name: string | undefined): string | undefined {
     return parseArgv()[name];
 }
 
+const INFRASTRUCTURE_ARGS = new Set([
+    "dest",
+    "export",
+    "e",
+    "dryRun",
+    "dry-run",
+    "d",
+    "version",
+]);
+
 function isNonInteractiveMode(): boolean {
-    return Object.keys(parseArgv()).length > 0;
+    return Object.keys(parseArgv()).some(
+        (key) => !INFRASTRUCTURE_ARGS.has(key),
+    );
 }
 
 async function runValidation(


### PR DESCRIPTION
## Problem

When running `scfz archetype --archetypeName "test" --archetypeBaseType "relationship"`, the CLI would still prompt interactively for the optional `description` field. Passing `--description ""` did not help either (wrong flag name — the prompt name is `archetypeDescription`).

## Root Cause

In `lib/utils/prompts.ts`, the `input()` function always fell back to `inquirerInput` when no CLI arg was provided — even for optional fields. There was no mechanism to detect non-interactive mode and skip prompts for optional fields.

## Fix

Added `isNonInteractiveMode()`: returns `true` when any named CLI args are present in `process.argv`.

In `input()`, when all of these are true, the function returns `rest.default ?? ""` instead of prompting:
- No CLI arg was provided for the field
- The field is optional (`required` is not set)
- A `name` is defined (the field is addressable via CLI)
- `isNonInteractiveMode()` is `true`

## Tests

**Unit tests** (`lib/utils/prompts.test.ts`):
- Optional field → returns `""` in non-interactive mode
- Optional field with `default` → returns the configured default
- No CLI args present → still prompts interactively (unchanged behaviour)
- Required field → still prompts even in non-interactive mode when not provided

**E2E tests** (`e2e/scfz-non-interactive.test.ts`):
- `scfz archetype --archetypeName HTTPS --archetypeBaseType relationship` — exits 0, creates DSL file, no `description`/`technology` lines
- Same with optional flags provided explicitly — values appear correctly in output

## Docs

Updated `--archetypeBaseType` as required flag and documented all optional flags in the skill reference.