### PR TITLE
feat: add Structurizr Dynamic view support

### DIFF
--- a/.agents/skills/scaffoldizr/SKILL.md
+++ b/.agents/skills/scaffoldizr/SKILL.md
@@ -80,12 +80,12 @@ All prompt questions can be answered via CLI flags using `--parameter "value"` o
 | `component` | `--elementName`, `--componentDescription`, `--componentTechnology` |
 | `person` | `--elementName`, `--personDescription` |
 | `external-system` | `--elementName`, `--extSystemDescription` |
-| `view` | `--viewType`, `--viewName`, `--viewDescription` |
+| `view` | `--viewType`, `--viewName`, `--viewDescription`, `--dynamicScope`, `--systemName`, `--containerName`, `--step-N` |
 | `constant` | `--constantName`, `--constantValue` |
 | `archetype` | `--archetypeName`, `--archetypeBaseType`, `--archetypeDescription` (optional), `--archetypeTechnology` (optional), `--archetypeTags` (optional) |
 | `theme` | `--themeAction "Add themes" --additionalThemes "<url1>,<url2>"` |
 
-Each element file documents the specific flags and CLI command for that generator.
+The `--viewType` flag accepts `landscape`, `deployment`, or `dynamic`. For other view types (`systemContext`, `container`, `component`), create the DSL file manually following the instructions in the view reference.
 
 - All the relevant documentation files are contained within the `./architecture` folder.
 - The main entrypoint is the `./architecture/workspace.dsl` file.

--- a/.agents/skills/scaffoldizr/assets/views/dynamic.dsl
+++ b/.agents/skills/scaffoldizr/assets/views/dynamic.dsl
@@ -1,9 +1,8 @@
 dynamic SoftwareSystemIdentifier "ViewKeyInPascalCase" {
-    title "View Title"
     description "Short description of the view. ${AUTHOR}"
-    autoLayout lr
-    
+
     1: ContainerA -> ExternalSystemB "Uses" "HTTPS"
     2: ContainerB -> DatabaseC "Reads from and writes to" "JDBC"
     3: User -> ContainerA "Interacts with" "Web UI"
+    autoLayout lr
 }

--- a/.agents/skills/scaffoldizr/references/view.md
+++ b/.agents/skills/scaffoldizr/references/view.md
@@ -38,33 +38,78 @@ Each workspace can contain one or more views, defined with the views block. Chec
 Unlike the other diagram types, Dynamic views are created by specifying the relationships that should be added to the view, within the dynamic block, as follows:
 
 ```dsl
-dynamic {identifier} "{view key}" {
-    title "{view title}"
-    description "{view description} ${AUTHOR}"
+dynamic {identifier} "{ViewKeyPascalCase}" {
+    description "{view description}. ${AUTHOR}"
 
-    [order:] {sourceIdentifier} -> {destinationIdentifier} "{relationship description}" "{technology}"
-    [order:] {sourceIdentifier} -> {destinationIdentifier} "{relationship description}" "{technology}"
-    [order:] {sourceIdentifier} -> {destinationIdentifier} "{relationship description}" "{technology}"
+    1: SourceIdentifier -> DestinationIdentifier "description" "technology"
+    2: SourceIdentifier -> DestinationIdentifier "description"
+    autoLayout lr
 }
 ```
 
-Where:
+Where `{identifier}` is:
 
-- `{identifier}`: is either a software system or container identifier. The identifier has to exist.
-- `{view key}`: is a unique key for the view in PascalCase.
-- `{view title}`: is a human friendly title for the view.
-- `{view description}`: is a short description of the view.
-- Each relationship line defines a relationship to be included in the view.
-- `{sourceIdentifier}` and `{destinationIdentifier}`: are the identifiers of the source and destination elements of the relationship. They have to exist.
-- `{relationship description}`: is a short description of the relationship.
-- `{technology}`: is the technology used in the relationship.
-- `[order:]`: is an optional order number to define the sequence of the relationships in the view.
+- `*` when scope is `workspace`
+- The DSL identifier of the software system when scope is `system`
+- The DSL identifier of the container when scope is `container`
+
+The DSL identifier comes from `element.properties["structurizr.dsl.identifier"]`, or falls back to the element name.
+
+#### Scope and available elements
+
+| Scope | Available elements |
+|---|---|
+| `workspace` | All elements in the workspace |
+| `system` | Containers of the selected system; other software systems; people; external systems. Components and the scoped system itself are excluded. |
+| `container` | Components of the selected container; people; external systems |
 
 _⚠️ Important Note_: Dynamic views require that the relationships being referenced already exist in the workspace. Before creating a dynamic view, always check if the relationships exist. If they do not exist, create them first in the `./architecture/relationships` folder.
+
+Step identifiers must use DSL identifiers (from `structurizr.dsl.identifier` property), not element display names. In interactive mode the tool resolves these automatically from workspace.json. In non-interactive mode the caller must provide the correct DSL identifiers.
 
 ### Deployment Views
 
 ## Using Scaffoldizr CLI (preferred for AI agents)
+
+```bash
+scfz view \
+  --viewType "dynamic" \
+  --dynamicScope "<workspace|system|container>" \
+  --systemName "<system name>" \
+  --containerName "<container name>" \
+  --viewName "<view name>" \
+  --viewDescription "<description>" \
+  --step-1 'SourceIdentifier -> DestinationIdentifier "description" "technology"' \
+  --step-2 'SourceIdentifier -> DestinationIdentifier "description"'
+```
+
+Flag rules:
+
+- `--viewType`: The type of view to create. For dynamic views, use `dynamic`. Other supported values: `landscape`, `deployment`.
+- `--dynamicScope`: required for `dynamic` view type. Values: `workspace`, `system`, `container`.
+- `--systemName`: required when scope is `system` or `container`.
+- `--containerName`: required when scope is `container`.
+- `--step-N`: defines one relationship step. `N` is the step number (integer). Repeat the same `N` to produce **parallel steps** (same order number in the DSL output). Steps are sorted by `N` before being written.
+- Step value format: `'SourceDslId -> DestinationDslId "description" "technology"'` — technology is optional.
+- `--step-N` flags are optional. If omitted, interactive prompts collect steps.
+
+**Parallel steps example:**
+
+```bash
+--step-1 'Web -> Db "Query" "SQL"' \
+--step-1 'Web -> Cache "Check cache" "Redis"' \
+--step-2 'Db -> Web "Results"'
+```
+
+Produces:
+
+```dsl
+1: Web -> Db "Query" "SQL"
+1: Web -> Cache "Check cache" "Redis"
+2: Db -> Web "Results"
+```
+
+For other view types:
 
 ```bash
 scfz view \
@@ -73,7 +118,7 @@ scfz view \
   --viewDescription "<description>"
 ```
 
-The `--viewType` flag accepts `landscape` or `deployment`. For other view types (`systemContext`, `container`, `component`, `dynamic`), create the DSL file manually following the instructions above.
+The `--viewType` flag accepts `landscape`, `deployment`, or `dynamic`. For other view types (`systemContext`, `container`, `component`), create the DSL file manually following the instructions in the view reference.
 
 ## References
 

--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,17 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+*.pid
+
+# Hook markers
+.dirty

--- a/architecture/workspace.json
+++ b/architecture/workspace.json
@@ -25,6 +25,13 @@
       "id" : "3",
       "status" : "Accepted",
       "title" : "Migrate to Unified Structurizr Docker Image"
+    }, {
+      "content" : "# 4. macOS and Windows CI E2E Tests Scoped to Version-Check Smoke Test Only\n\nDate: 2026-04-10\n\n## Status\n\nAccepted\n\n## Context\n\n- The `structurizr/structurizr` Docker image (introduced in ADR 0003) only provides Linux builds (`linux/amd64`, `linux/arm64`). There is no Windows or macOS-compatible Docker image.\n- The Scaffoldizr e2e test suite relies on the `structurizr/structurizr` Docker image for most tests (export, run, update scripts).\n- GitHub Actions Windows runners (`windows-latest`) cannot run Linux Docker containers without additional tooling (WSL2 + Docker Desktop license or equivalent), which is not available in standard CI environments.\n- GitHub Actions macOS runners (`macos-latest`) do not have Docker pre-installed, and neither VZ (Apple Virtualization.framework) nor QEMU-based VM solutions (e.g. Colima) work reliably on these runners due to missing hypervisor support.\n- Running the full e2e suite on macOS or Windows CI would require either: (a) a native binary for that platform (which does not exist), (b) a platform-compatible Docker image (which does not exist), or (c) mocking Docker entirely (which would reduce test fidelity).\n\n## Decision\n\n- macOS and Windows CI are both scoped to a single **smoke test**: a version-check only (`scfz --version`) that validates the binary was built and runs correctly on that platform.\n- A dedicated npm script `test:e2e:smoke:windows` is used for both macOS and Windows jobs. It runs only `e2e/scfz-general.test.ts`, which contains the `@smoke` tagged version-check test and has zero Docker dependency.\n- The `.github/workflows/e2e.yaml` macOS and Windows jobs unconditionally run `test:e2e:smoke:windows`. There is no full e2e path for either platform.\n- Linux CI jobs (`ubuntu-latest`) continue to run the full e2e suite with Docker available natively.\n- Docker-dependent e2e tests are not tagged `@smoke` and are never run in macOS or Windows jobs.\n\n## Consequences\n\n- Positive: macOS and Windows CI remain fast and reliable — no Docker dependency, no flaky VM/container setup steps.\n- Positive: Both macOS and Windows binaries are still validated in CI for every PR (build succeeds + version output correct).\n- Positive: No licensing or infrastructure cost for Docker on macOS/Windows CI runners.\n- Positive: Full e2e coverage is provided by Linux runners which have native Docker support.\n- Negative: Docker-dependent scenarios (export, run, update scripts) are not tested on macOS or Windows in CI. Any platform-specific behaviour differences would only be caught locally or in production.\n- Negative: If future macOS or Windows-compatible Structurizr Docker images become available, this ADR should be revisited.\n\n## References\n\n- ADR 0003: Migrate to Unified Structurizr Docker Image\n- [structurizr/structurizr Docker Hub](https://hub.docker.com/r/structurizr/structurizr) — Linux-only image manifests\n- `.github/workflows/e2e.yaml` — CI workflow with platform-specific e2e steps\n- `package.json` `test:e2e:smoke:windows` script\n",
+      "date" : "2026-04-10T00:00:00Z",
+      "format" : "Markdown",
+      "id" : "4",
+      "status" : "Accepted",
+      "title" : "macOS and Windows CI E2E Tests Scoped to Version-Check Smoke Test Only"
     } ],
     "sections" : [ {
       "content" : "\n## Motivation\n\n[Structurizr Workspaces](https://docs.structurizr.com/workspaces) are a great way to document and share architecture diagrams in the [C4 model](https://c4model.com/). However, the diagram creation is freeform and there are no guidelines to break code into files, leaving architects and developers with a feeling of not knowing where to start.\n\nThis is an opinionated scaffolding tool written in TypeScript/[Bun](https://bun.sh/) that attempts to create the building blocks of a solid system architecture documentation, that eases up the entry barrier for newcomers as well as allowing architects experienced in Structurizr to follow a convention while setting them up for success.\n",
@@ -33,7 +40,7 @@
       "order" : 1,
       "title" : ""
     }, {
-      "content" : "\n## Installation\n\nRun in your terminal:\n\n```bash\ncurl -s https://formulamonks.github.io/scaffoldizr/assets/install.sh | sh\n```\n\nThen, verify the tool is correctly installed:\n\n```bash\nscfz --version\n```\n\n## Usage\n\nOnce installed, run in your terminal:\n\n```bash\nscfz --dest {docs_folder}\n```\n\nwhere `{docs_folder}` is a folder where dsl files will be generated. The tool creates an `architecture/` folder and starts scaffolding from there. `{docs_folder}` default value is current working directory. So you can just issue `scfz` command.\n\n### Options\n\n- `--help`: Show help information\n- `--version`: Show current tool version\n- `--dest <path>`: Target architecture folder (default: current directory)\n- `-e, --export`: Use Structurizr unified CLI (Docker) to export the workspace to JSON (default: false)\n",
+      "content" : "\n## Installation\n\n### macOS / Linux\n\nRun in your terminal:\n\n```bash\ncurl -s https://formulamonks.github.io/scaffoldizr/assets/install.sh | sh\n```\n\n### Windows\n\nRun in PowerShell:\n\n```powershell\nirm https://formulamonks.github.io/scaffoldizr/assets/install.ps1 | iex\n```\n\nThen, verify the tool is correctly installed:\n\n```bash\nscfz --version\n```\n\n## Usage\n\nOnce installed, run in your terminal:\n\n```bash\nscfz --dest {docs_folder}\n```\n\nwhere `{docs_folder}` is a folder where dsl files will be generated. The tool creates an `architecture/` folder and starts scaffolding from there. `{docs_folder}` default value is current working directory. So you can just issue `scfz` command.\n\n### Options\n\n- `--help`: Show help information\n- `--version`: Show current tool version\n- `--dest <path>`: Target architecture folder (default: current directory)\n- `-e, --export`: Use Structurizr unified CLI (Docker) to export the workspace to JSON (default: false)\n",
       "filename" : "02-getting-started.md",
       "format" : "Markdown",
       "order" : 2,
@@ -68,10 +75,16 @@
       "format" : "Markdown",
       "order" : 7,
       "title" : ""
+    }, {
+      "content" : "\nScaffoldizr tracks compatibility between your workspace and the CLI tool using a version header. When you upgrade the `scfz` tool, your existing workspace may become \"outdated\" if it was generated with an older version.\n\nScaffoldizr stamps a `# Generated by Scaffoldizr vX.X.X` header in the `workspace.dsl` file to track this compatibility. When the tool version is newer than the workspace version, a warning banner will appear.\n\n## Overview\n\nThe `migrate` command helps you keep your workspace up to date with the latest Scaffoldizr features, script improvements, and compatibility standards.\n\n## Running the migrate command\n\nTo migrate your workspace to the current version of Scaffoldizr, run:\n\n```bash\nscfz migrate\n```\n\nYou can also specify a destination path if your workspace is not in the current directory:\n\n```bash\nscfz migrate --dest <path>\n```\n\n## Dry-run mode\n\nIf you want to see what changes would be applied without actually modifying any files, use the dry-run flag:\n\n```bash\nscfz migrate --dry-run\n```\n\nThis will list all migrations that would be executed and any files that would be modified.\n\n## What migrations do\n\nCurrently, Scaffoldizr includes the following bundled migrations:\n\n1.  **Add version header**: Stamps the `# Generated by Scaffoldizr vX.X.X` header at the top of your `workspace.dsl` file if it is missing or outdated.\n2.  **Regenerate scripts**: Overwrites the workspace shell scripts with the latest bundled templates to ensure compatibility with new tool features. This affects:\n    *   `scripts/run.sh`\n    *   `scripts/run.ps1`\n    *   `scripts/update.sh`\n    *   `scripts/update.ps1`\n\n## When to run\n\nYou should run the `migrate` command:\n*   Immediately after upgrading the `scfz` tool to a new version.\n*   Whenever the \"Your workspace is outdated!\" banner appears when running `scfz`.\n\n## Flags\n\n| Flag | Shorthand | Description | Default |\n| :--- | :--- | :--- | :--- |\n| `--dest` | | Path to the workspace directory | `.` |\n| `--dry-run` | `-d` | Preview changes without writing files | `false` |\n",
+      "filename" : "08-migrate.md",
+      "format" : "Markdown",
+      "order" : 8,
+      "title" : ""
     } ]
   },
   "id" : 1,
-  "lastModifiedDate" : "2026-04-10T17:04:35Z",
+  "lastModifiedDate" : "2026-06-05T01:44:20Z",
   "model" : {
     "people" : [ {
       "description" : "Architect",
@@ -304,7 +317,7 @@
       "externalContainerBoundariesVisible" : false,
       "key" : "Generator",
       "name" : "Component View: Scaffoldizr - scfz",
-      "order" : 3,
+      "order" : 4,
       "relationships" : [ {
         "id" : "17"
       }, {
@@ -349,13 +362,43 @@
       "externalSoftwareSystemBoundariesVisible" : false,
       "key" : "ScaffoldizrCLI",
       "name" : "Container View: Scaffoldizr",
-      "order" : 2,
+      "order" : 3,
       "relationships" : [ {
         "id" : "14"
       }, {
         "id" : "16"
       } ],
       "softwareSystemId" : "3"
+    } ],
+    "dynamicViews" : [ {
+      "automaticLayout" : {
+        "edgeSeparation" : 50,
+        "nodeSeparation" : 50,
+        "rankDirection" : "LeftRight",
+        "rankSeparation" : 100,
+        "vertices" : true
+      },
+      "description" : "Untitled view. Author: Formula.monks <andres.zorro@mediamonks.com>",
+      "elementId" : "3",
+      "elements" : [ {
+        "id" : "1",
+        "x" : 0,
+        "y" : 0
+      }, {
+        "id" : "9",
+        "x" : 0,
+        "y" : 0
+      } ],
+      "externalBoundariesVisible" : false,
+      "key" : "IHbljd",
+      "name" : "Dynamic View: Scaffoldizr",
+      "order" : 1,
+      "relationships" : [ {
+        "description" : "Uses",
+        "id" : "11",
+        "order" : "1",
+        "response" : false
+      } ]
     } ],
     "systemContextViews" : [ {
       "description" : "Scaffolding tool. Author: Formula.monks <andres.zorro@mediamonks.com>",
@@ -379,7 +422,7 @@
       "enterpriseBoundaryVisible" : true,
       "key" : "Scaffoldizr",
       "name" : "System Context View: Scaffoldizr",
-      "order" : 1,
+      "order" : 2,
       "relationships" : [ {
         "id" : "10"
       }, {

--- a/e2e/scfz-non-interactive.test.ts
+++ b/e2e/scfz-non-interactive.test.ts
@@ -325,3 +325,139 @@ describe("e2e: non-interactive validation failures", () => {
         }
     });
 });
+
+describe("e2e: non-interactive dynamic view", () => {
+    const folder = join(
+        TMP_FOLDER,
+        `test-${(1000 + Math.ceil(Math.random() * 1000)).toString(16)}`,
+    );
+
+    beforeAll(async () => {
+        await createWorkspaceFromCLI(folder, "softwaresystem", {
+            id: 1,
+            name: "Test",
+            description: "",
+            lastModifiedDate: "",
+            properties: {},
+            model: {
+                people: [],
+                softwareSystems: [
+                    {
+                        id: "1",
+                        tags: "Element,Software System",
+                        properties: {},
+                        name: "App",
+                        description: "",
+                        documentation: { sections: [], images: [] },
+                        relationships: [],
+                        location: "Internal",
+                        containers: [
+                            {
+                                id: "2",
+                                tags: "Element,Container",
+                                properties: {},
+                                name: "Web",
+                                description: "",
+                                documentation: { sections: [], images: [] },
+                                relationships: [],
+                                technology: "",
+                            },
+                            {
+                                id: "3",
+                                tags: "Element,Container",
+                                properties: {},
+                                name: "Db",
+                                description: "",
+                                documentation: { sections: [], images: [] },
+                                relationships: [],
+                                technology: "",
+                                components: [
+                                    {
+                                        id: "4",
+                                        tags: "Element,Component",
+                                        properties: {},
+                                        name: "Cache",
+                                        description: "",
+                                        documentation: {
+                                            sections: [],
+                                            images: [],
+                                        },
+                                        relationships: [],
+                                        technology: "",
+                                    },
+                                    {
+                                        id: "5",
+                                        tags: "Element,Component",
+                                        properties: {},
+                                        name: "Engine",
+                                        description: "",
+                                        documentation: {
+                                            sections: [],
+                                            images: [],
+                                        },
+                                        relationships: [],
+                                        technology: "",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                deploymentNodes: [],
+            },
+            configuration: {
+                branding: {},
+                styles: {},
+                terminology: {},
+                scope: "Software System",
+            },
+            documentation: { sections: [], images: [] },
+            views: {
+                systemLandscapeViews: [],
+                systemContextViews: [],
+                configuration: {
+                    branding: {},
+                    styles: {},
+                    terminology: {},
+                },
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await $`rm -rf ${folder}`;
+    });
+
+    test("should allow dynamic container scope via CLI args", async () => {
+        const proc = spawn([
+            "dist/scfz",
+            "view",
+            "--dest",
+            folder,
+            "--viewType",
+            "dynamic",
+            "--dynamicScope",
+            "container",
+            "--systemName",
+            "App",
+            "--containerName",
+            "Db",
+            "--viewName",
+            "DynTest",
+            "--viewDescription",
+            "Test",
+            "--step-1",
+            'Cache -> Engine "test"',
+        ]);
+
+        await proc.exited;
+        expect(proc.exitCode).toBe(0);
+
+        const viewContents = await file(
+            `${folder}/architecture/views/dyn-test.dsl`,
+        ).text();
+
+        expect(viewContents).toContain('dynamic Db "DynTest"');
+        expect(viewContents).toContain('Cache -> Engine "test"');
+    });
+});

--- a/e2e/scfz-softwaresystem.test.ts
+++ b/e2e/scfz-softwaresystem.test.ts
@@ -228,6 +228,7 @@ describe("e2e: Software System", () => {
             keypress.DOWN,
             keypress.DOWN,
             keypress.ENTER,
+            keypress.DOWN,
             keypress.ENTER,
             "Test View",
             keypress.ENTER,

--- a/e2e/scfz-softwaresystem.test.ts
+++ b/e2e/scfz-softwaresystem.test.ts
@@ -248,6 +248,98 @@ describe("e2e: Software System", () => {
         expect(elementContents).toContain('deployment TestSystem "Test View"');
     });
 
+    test("should add a dynamic container-scoped view interactively", async () => {
+        const addContainerProc = spawn([
+            "dist/scfz",
+            "container",
+            "--dest",
+            folder,
+            "--elementName",
+            "Db",
+            "--containerDescription",
+            "Database",
+            "--containerType",
+            "None of the above",
+            "--containerTechnology",
+            "PostgreSQL",
+        ]);
+
+        await addContainerProc.exited;
+        expect(addContainerProc.exitCode).toBe(0);
+
+        const addComponentProc = spawn([
+            "dist/scfz",
+            "component",
+            "--dest",
+            folder,
+            "--container",
+            "Test System/Db",
+            "--elementName",
+            "Cache",
+            "--componentDescription",
+            "Cache component",
+            "--componentTechnology",
+            "Redis",
+        ]);
+
+        await addComponentProc.exited;
+        expect(addComponentProc.exitCode).toBe(0);
+
+        const addSecondComponentProc = spawn([
+            "dist/scfz",
+            "component",
+            "--dest",
+            folder,
+            "--container",
+            "Test System/Db",
+            "--elementName",
+            "Engine",
+            "--componentDescription",
+            "Engine component",
+            "--componentTechnology",
+            "PostgreSQL",
+        ]);
+
+        await addSecondComponentProc.exited;
+        expect(addSecondComponentProc.exitCode).toBe(0);
+
+        const proc = spawn(["dist/scfz", "view", "--dest", folder], {
+            stdin: "pipe",
+        });
+
+        loop(proc, [
+            keypress.ENTER,
+            keypress.DOWN,
+            keypress.ENTER,
+            keypress.DOWN,
+            keypress.ENTER,
+            keypress.ENTER,
+            keypress.DOWN,
+            keypress.ENTER,
+            "test",
+            keypress.ENTER,
+            keypress.ENTER,
+            "no",
+            keypress.ENTER,
+            "Dynamic Container View",
+            keypress.ENTER,
+            "Container scoped test",
+            keypress.ENTER,
+        ]);
+
+        const response = await new Response(proc.stdout).text();
+        console.log(`Scaffoldizr Output:\n${response}`);
+
+        expect(proc.exitCode).toBe(0);
+
+        const viewContents = await file(
+            `${folder}/architecture/views/dynamic-container-view.dsl`,
+        ).text();
+
+        expect(viewContents).toContain('dynamic Db "DynamicContainerView"');
+        expect(viewContents).toContain('Cache -> Engine "test"');
+    });
+
     test("@smoke: should add a new relationship", async () => {
         const proc = spawn(["dist/scfz", "--dest", folder, "--export"], {
             stdin: "pipe",

--- a/e2e/scfz-softwaresystem.test.ts
+++ b/e2e/scfz-softwaresystem.test.ts
@@ -343,7 +343,6 @@ describe("e2e: Software System", () => {
             keypress.ENTER,
             keypress.DOWN,
             keypress.ENTER,
-            keypress.DOWN,
             keypress.ENTER,
             "Dynamic Container View",
             keypress.ENTER,
@@ -362,6 +361,8 @@ describe("e2e: Software System", () => {
 
         const response = await new Response(proc.stdout).text();
         console.log(`Scaffoldizr Output:\n${response}`);
+
+        await proc.exited;
 
         expect(proc.exitCode).toBe(0);
 

--- a/e2e/scfz-softwaresystem.test.ts
+++ b/e2e/scfz-softwaresystem.test.ts
@@ -254,6 +254,7 @@ describe("e2e: Software System", () => {
             "container",
             "--dest",
             folder,
+            "--export",
             "--elementName",
             "Db",
             "--containerDescription",
@@ -262,34 +263,19 @@ describe("e2e: Software System", () => {
             "None of the above",
             "--containerTechnology",
             "PostgreSQL",
+            "--relationshipNames",
+            "",
         ]);
 
         await addContainerProc.exited;
         expect(addContainerProc.exitCode).toBe(0);
 
-        const addComponentProc = spawn([
+        const addEngineProc = spawn([
             "dist/scfz",
             "component",
             "--dest",
             folder,
-            "--container",
-            "Test System/Db",
-            "--elementName",
-            "Cache",
-            "--componentDescription",
-            "Cache component",
-            "--componentTechnology",
-            "Redis",
-        ]);
-
-        await addComponentProc.exited;
-        expect(addComponentProc.exitCode).toBe(0);
-
-        const addSecondComponentProc = spawn([
-            "dist/scfz",
-            "component",
-            "--dest",
-            folder,
+            "--export",
             "--container",
             "Test System/Db",
             "--elementName",
@@ -298,10 +284,55 @@ describe("e2e: Software System", () => {
             "Engine component",
             "--componentTechnology",
             "PostgreSQL",
+            "--relationshipNames",
+            "",
         ]);
 
-        await addSecondComponentProc.exited;
-        expect(addSecondComponentProc.exitCode).toBe(0);
+        await addEngineProc.exited;
+        expect(addEngineProc.exitCode).toBe(0);
+
+        const addCacheProc = spawn([
+            "dist/scfz",
+            "component",
+            "--dest",
+            folder,
+            "--export",
+            "--container",
+            "Test System/Db",
+            "--elementName",
+            "Cache",
+            "--componentDescription",
+            "Cache component",
+            "--componentTechnology",
+            "Redis",
+            "--relationshipNames",
+            "",
+        ]);
+
+        await addCacheProc.exited;
+        expect(addCacheProc.exitCode).toBe(0);
+
+        const addRelationshipProc = spawn(
+            [
+                "dist/scfz",
+                "relationship",
+                "--dest",
+                folder,
+                "--export",
+                "--element",
+                "Component/Test System/Db/Cache",
+                "--relationshipNames",
+                "Db_Engine",
+            ],
+            {
+                stdin: "pipe",
+            },
+        );
+
+        loop(addRelationshipProc, [keypress.ENTER]);
+
+        await addRelationshipProc.exited;
+        expect(addRelationshipProc.exitCode).toBe(0);
 
         const proc = spawn(["dist/scfz", "view", "--dest", folder], {
             stdin: "pipe",
@@ -313,17 +344,18 @@ describe("e2e: Software System", () => {
             keypress.ENTER,
             keypress.DOWN,
             keypress.ENTER,
+            "Dynamic Container View",
+            keypress.ENTER,
+            "Container scoped test",
             keypress.ENTER,
             keypress.DOWN,
+            keypress.ENTER,
             keypress.ENTER,
             "test",
             keypress.ENTER,
             keypress.ENTER,
-            "no",
             keypress.ENTER,
-            "Dynamic Container View",
-            keypress.ENTER,
-            "Container scoped test",
+            "n",
             keypress.ENTER,
         ]);
 
@@ -337,7 +369,7 @@ describe("e2e: Software System", () => {
         ).text();
 
         expect(viewContents).toContain('dynamic Db "DynamicContainerView"');
-        expect(viewContents).toContain('Cache -> Engine "test"');
+        expect(viewContents).toContain('Db_Cache -> Db_Engine "test"');
     });
 
     test("@smoke: should add a new relationship", async () => {

--- a/lib/generators/view.ts
+++ b/lib/generators/view.ts
@@ -67,14 +67,73 @@ async function collectDynamicSteps(): Promise<string[]> {
 
     const dynamicSteps: string[] = [];
 
-    for (let stepIndex = 1; ; stepIndex += 1) {
-        const step = await input({
-            message: `Dynamic step ${stepIndex}:`,
+    const normalizeRelationshipPart = (value: string) => value.trim();
+
+    const assembleRelationship = (
+        sourceElement: string,
+        destinationElement: string,
+        relationshipDescription: string,
+        technologyChannel: string,
+    ) => {
+        const relationshipParts = [
+            `${normalizeRelationshipPart(sourceElement)} -> ${normalizeRelationshipPart(destinationElement)}`,
+            `"${normalizeRelationshipPart(relationshipDescription)}"`,
+        ];
+
+        const normalizedTechnologyChannel =
+            normalizeRelationshipPart(technologyChannel);
+
+        if (normalizedTechnologyChannel.length > 0) {
+            relationshipParts.push(`"${normalizedTechnologyChannel}"`);
+        }
+
+        return relationshipParts.join(" ");
+    };
+
+    for (;;) {
+        const sourceElement = await input({
+            message: "Source element (e.g., User, WebApplication):",
+            validate: stringEmpty,
         });
+
+        const destinationElement = await input({
+            message: "Destination element (e.g., API, Database):",
+            validate: stringEmpty,
+        });
+
+        const relationshipDescription = await input({
+            message: "Relationship description (e.g., Visits, Fetches):",
+            validate: stringEmpty,
+        });
+
+        const technologyChannel = await input({
+            message: "Technology/Channel (optional, e.g., JSON/HTTPS, gRPC):",
+        });
+
+        const step = assembleRelationship(
+            sourceElement,
+            destinationElement,
+            relationshipDescription,
+            technologyChannel,
+        );
 
         if (step.trim().length === 0) break;
 
         dynamicSteps.push(step);
+
+        const addAnotherStep = await input({
+            message:
+                "Add another step? (yes/no or press Enter for yes, type 'done'/'no' to stop)",
+        });
+
+        const normalizedAddAnotherStep = addAnotherStep.trim().toLowerCase();
+        if (
+            normalizedAddAnotherStep === "done" ||
+            normalizedAddAnotherStep === "no" ||
+            normalizedAddAnotherStep === "n"
+        ) {
+            break;
+        }
     }
 
     return dynamicSteps;

--- a/lib/generators/view.ts
+++ b/lib/generators/view.ts
@@ -3,7 +3,10 @@ import { skipUnlessViewType, whenViewType } from "../utils/actions/utils";
 import type { GeneratorDefinition } from "../utils/generator";
 import { Elements } from "../utils/labels";
 import { input, select } from "../utils/prompts";
-import { resolveSystemQuestion } from "../utils/questions/system";
+import {
+    getAllWorkspaceElements,
+    resolveSystemQuestion,
+} from "../utils/questions/system";
 import {
     chainValidators,
     stringEmpty,
@@ -13,11 +16,103 @@ import { getWorkspaceJson, getWorkspacePath } from "../utils/workspace";
 
 type ViewAnswers = {
     viewType: string;
+    dynamicScope?: string;
+    dynamicScopeType?: string;
+    dynamicScopeElement?: string;
+    dynamicSteps?: string[];
     viewName: string;
     viewDescription: string;
     systemName?: string;
+    containerName?: string;
     instanceDescription?: string;
 };
+
+function getDynamicStepFlags(): string[] {
+    const dynamicStepFlags = new Map<number, string>();
+
+    const argv = process.argv.slice(2);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = argv[index];
+
+        const match = /^--step-(\d+)(?:=(.*))?$/.exec(argument);
+        if (!match) continue;
+
+        const stepNumber = Number(match[1]);
+        const inlineValue = match[2];
+
+        if (inlineValue !== undefined) {
+            dynamicStepFlags.set(stepNumber, inlineValue);
+            continue;
+        }
+
+        const nextArgument = argv[index + 1];
+        if (nextArgument !== undefined && !nextArgument.startsWith("--")) {
+            dynamicStepFlags.set(stepNumber, nextArgument);
+            index += 1;
+            continue;
+        }
+
+        dynamicStepFlags.set(stepNumber, "");
+    }
+
+    return [...dynamicStepFlags.entries()]
+        .sort(([left], [right]) => left - right)
+        .map(([, value]) => value);
+}
+
+async function collectDynamicSteps(): Promise<string[]> {
+    const stepFlags = getDynamicStepFlags();
+    if (stepFlags.length > 0) return stepFlags;
+
+    const dynamicSteps: string[] = [];
+
+    for (let stepIndex = 1; ; stepIndex += 1) {
+        const step = await input({
+            message: `Dynamic step ${stepIndex}:`,
+        });
+
+        if (step.trim().length === 0) break;
+
+        dynamicSteps.push(step);
+    }
+
+    return dynamicSteps;
+}
+
+function getDynamicScopeChoices(workspaceScope?: string) {
+    if (workspaceScope === "softwaresystem") {
+        return [
+            { name: "System", value: "system" },
+            { name: "Container", value: "container" },
+        ];
+    }
+
+    return [
+        { name: "Workspace", value: "workspace" },
+        { name: "System", value: "system" },
+    ];
+}
+
+function getSystemContainerChoices(
+    workspaceInfo: Awaited<ReturnType<typeof getWorkspaceJson>>,
+    systemName: string,
+) {
+    const workspaceElements = getAllWorkspaceElements(workspaceInfo, {
+        includeContainers: true,
+        includeComponents: false,
+    });
+
+    return workspaceElements
+        .filter(
+            (element) =>
+                element.systemName === systemName && "containerName" in element,
+        )
+        .map((element) => ({
+            name: element.name,
+            value: element.name,
+        }));
+}
 
 // TODO: Other types of views
 // - Dynamic
@@ -32,23 +127,54 @@ const generator: GeneratorDefinition<ViewAnswers> = {
             getWorkspacePath(generator.destPath),
         );
 
+        const workspaceScope =
+            workspaceInfo?.configuration.scope?.toLowerCase();
+
         const viewType = await select<string>({
             name: "viewType",
             message: "View type:",
             choices: [
-                // "dynamic",
+                { name: "Dynamic", value: "dynamic" },
                 // "filtered",
                 { name: "Deployment", value: "deployment" },
                 { name: "Landscape", value: "landscape" },
             ],
         });
 
+        const dynamicScope =
+            viewType === "dynamic"
+                ? await select<string>({
+                      name: "dynamicScope",
+                      message: "Dynamic scope:",
+                      choices: getDynamicScopeChoices(workspaceScope),
+                  })
+                : undefined;
+
         const systemName =
-            viewType !== "landscape"
+            viewType !== "landscape" && dynamicScope !== "workspace"
                 ? await resolveSystemQuestion(
                       workspaceInfo ?? generator.destPath,
                   )
                 : undefined;
+
+        const containerName =
+            viewType === "dynamic" && dynamicScope === "container"
+                ? await select<string>({
+                      name: "containerName",
+                      message: "Container:",
+                      choices: getSystemContainerChoices(
+                          workspaceInfo,
+                          systemName ?? "",
+                      ),
+                  })
+                : undefined;
+
+        const dynamicScopeElement =
+            dynamicScope === "container"
+                ? containerName
+                : dynamicScope === "system"
+                  ? systemName
+                  : undefined;
 
         const viewName = await input({
             name: "viewName",
@@ -65,6 +191,9 @@ const generator: GeneratorDefinition<ViewAnswers> = {
             default: "Untitled view",
         });
 
+        const dynamicSteps =
+            viewType === "dynamic" ? await collectDynamicSteps() : undefined;
+
         const instanceDescription =
             viewType === "deployment"
                 ? await input({
@@ -78,13 +207,24 @@ const generator: GeneratorDefinition<ViewAnswers> = {
 
         return {
             viewType,
+            dynamicScope,
+            dynamicScopeType: dynamicScope,
+            dynamicScopeElement,
+            dynamicSteps,
             viewName,
             viewDescription,
             systemName,
+            containerName,
             instanceDescription,
         };
     },
     actions: [
+        {
+            skip: skipUnlessViewType("dynamic"),
+            type: "add",
+            path: "architecture/views/{{kebabCase viewName}}.dsl",
+            templateFile: "templates/views/dynamic.hbs",
+        } as AddAction<ViewAnswers>,
         {
             skip: skipUnlessViewType("deployment"),
             type: "add",

--- a/lib/generators/view.ts
+++ b/lib/generators/view.ts
@@ -1,5 +1,5 @@
 import type { AddAction } from "../utils/actions";
-import { skipUnlessViewType, whenViewType } from "../utils/actions/utils";
+import { skipUnlessViewType } from "../utils/actions/utils";
 import type { GeneratorDefinition } from "../utils/generator";
 import { Elements } from "../utils/labels";
 import { confirm, input, Separator, select } from "../utils/prompts";

--- a/lib/generators/view.ts
+++ b/lib/generators/view.ts
@@ -2,7 +2,7 @@ import type { AddAction } from "../utils/actions";
 import { skipUnlessViewType, whenViewType } from "../utils/actions/utils";
 import type { GeneratorDefinition } from "../utils/generator";
 import { Elements } from "../utils/labels";
-import { input, select } from "../utils/prompts";
+import { confirm, input, Separator, select } from "../utils/prompts";
 import {
     getAllWorkspaceElements,
     resolveSystemQuestion,
@@ -10,9 +10,25 @@ import {
 import {
     chainValidators,
     stringEmpty,
+    validateDuplicatedViewFile,
     validateDuplicatedViews,
 } from "../utils/questions/validators";
-import { getWorkspaceJson, getWorkspacePath } from "../utils/workspace";
+import {
+    type DynamicScope,
+    getDynamicStepElementChoices,
+    getRelationshipsForElement,
+    getSystemContainerChoices,
+    type ViewElement,
+} from "../utils/questions/view";
+import type { StructurizrWorkspace } from "../utils/workspace";
+import {
+    getWorkspaceDslScope,
+    getWorkspaceJson,
+    getWorkspacePath,
+    normalizeWorkspaceScope,
+} from "../utils/workspace";
+
+type ChoiceItem = { name: string; value: string; _element: ViewElement };
 
 type ViewAnswers = {
     viewType: string;
@@ -28,7 +44,7 @@ type ViewAnswers = {
 };
 
 function getDynamicStepFlags(): string[] {
-    const dynamicStepFlags = new Map<number, string>();
+    const dynamicStepFlags: Array<[number, string]> = [];
 
     const argv = process.argv.slice(2);
 
@@ -42,30 +58,67 @@ function getDynamicStepFlags(): string[] {
         const inlineValue = match[2];
 
         if (inlineValue !== undefined) {
-            dynamicStepFlags.set(stepNumber, inlineValue);
+            dynamicStepFlags.push([stepNumber, inlineValue]);
             continue;
         }
 
         const nextArgument = argv[index + 1];
         if (nextArgument !== undefined && !nextArgument.startsWith("--")) {
-            dynamicStepFlags.set(stepNumber, nextArgument);
+            dynamicStepFlags.push([stepNumber, nextArgument]);
             index += 1;
             continue;
         }
 
-        dynamicStepFlags.set(stepNumber, "");
+        dynamicStepFlags.push([stepNumber, ""]);
     }
 
-    return [...dynamicStepFlags.entries()]
+    return dynamicStepFlags
         .sort(([left], [right]) => left - right)
-        .map(([, value]) => value);
+        .map(([stepNum, value]) => `${stepNum}: ${value}`);
 }
 
-async function collectDynamicSteps(): Promise<string[]> {
+function getDslIdentifier(
+    workspaceInfo: StructurizrWorkspace | undefined,
+    elementName: string,
+): string {
+    const allElements = getAllWorkspaceElements(workspaceInfo, {
+        includeContainers: true,
+        includeComponents: false,
+    });
+    const element = allElements.find(
+        (workspaceElement) => workspaceElement.name === elementName,
+    );
+    return element?.properties?.["structurizr.dsl.identifier"] ?? elementName;
+}
+
+async function collectDynamicSteps(
+    workspaceInfo: StructurizrWorkspace | undefined,
+    dynamicScope: DynamicScope,
+    systemName?: string,
+    containerName?: string,
+): Promise<string[]> {
     const stepFlags = getDynamicStepFlags();
     if (stepFlags.length > 0) return stepFlags;
 
+    const dynamicStepElements = getDynamicStepElementChoices(
+        workspaceInfo,
+        dynamicScope,
+        systemName,
+        containerName,
+    );
+
+    const nonSeparatorElements = dynamicStepElements.filter(
+        (el): el is ChoiceItem => !(el instanceof Separator),
+    );
+
+    if (nonSeparatorElements.length === 0) {
+        throw new Error(
+            "No elements available for the selected dynamic scope.",
+        );
+    }
+
     const dynamicSteps: string[] = [];
+    let lastUsedPosition = 0;
 
     const normalizeRelationshipPart = (value: string) => value.trim();
 
@@ -90,16 +143,86 @@ async function collectDynamicSteps(): Promise<string[]> {
         return relationshipParts.join(" ");
     };
 
-    for (;;) {
-        const sourceElement = await input({
-            message: "Source element (e.g., User, WebApplication):",
-            validate: stringEmpty,
+    while (true) {
+        const sourceElementKey = await select<string>({
+            name: "sourceElement",
+            message: "Source element:",
+            choices: dynamicStepElements,
         });
 
-        const destinationElement = await input({
-            message: "Destination element (e.g., API, Database):",
-            validate: stringEmpty,
+        const selectedSourceElement = nonSeparatorElements.find(
+            (element) => element.value === sourceElementKey,
+        );
+
+        if (!selectedSourceElement) {
+            throw new Error(
+                "Selected source element was not found in workspace.",
+            );
+        }
+
+        const relatedElements = getRelationshipsForElement(
+            selectedSourceElement._element,
+            nonSeparatorElements.map(({ _element }) => _element),
+        );
+        const relatedElementIds = new Set(relatedElements.map(({ id }) => id));
+        const destinationChoices: Array<(typeof dynamicStepElements)[number]> =
+            [];
+        let currentGroupSeparator: Separator | undefined;
+        const currentGroupItems: Array<(typeof dynamicStepElements)[number]> =
+            [];
+
+        const flushGroup = (): void => {
+            if (currentGroupItems.length === 0) return;
+
+            if (currentGroupSeparator !== undefined) {
+                destinationChoices.push(
+                    currentGroupSeparator,
+                    ...currentGroupItems,
+                );
+            } else {
+                destinationChoices.push(...currentGroupItems);
+            }
+
+            currentGroupSeparator = undefined;
+            currentGroupItems.length = 0;
+        };
+
+        for (const item of dynamicStepElements) {
+            if (item instanceof Separator) {
+                flushGroup();
+                currentGroupSeparator = item;
+                continue;
+            }
+
+            if (relatedElementIds.has(item._element.id)) {
+                currentGroupItems.push(item);
+            }
+        }
+
+        flushGroup();
+
+        if (destinationChoices.length === 0) {
+            console.log(
+                "No valid destination elements found for the selected source. Exiting.",
+            );
+            break;
+        }
+
+        const destinationElementKey = await select<string>({
+            name: "destinationElement",
+            message: "Destination element:",
+            choices: destinationChoices,
         });
+
+        const selectedDestinationElement = nonSeparatorElements.find(
+            (element) => element.value === destinationElementKey,
+        );
+
+        if (!selectedDestinationElement) {
+            throw new Error(
+                "Selected destination element was not found in workspace.",
+            );
+        }
 
         const relationshipDescription = await input({
             message: "Relationship description (e.g., Visits, Fetches):",
@@ -110,37 +233,41 @@ async function collectDynamicSteps(): Promise<string[]> {
             message: "Technology/Channel (optional, e.g., JSON/HTTPS, gRPC):",
         });
 
+        const suggestedPosition = lastUsedPosition + 1;
+        const positionInput = await input({
+            message: `Step position (default: ${suggestedPosition}):`,
+        });
+        const stepPosition =
+            positionInput.trim() === "" ||
+            Number.isNaN(Number(positionInput.trim()))
+                ? suggestedPosition
+                : Number(positionInput.trim());
+        lastUsedPosition = stepPosition;
+
         const step = assembleRelationship(
-            sourceElement,
-            destinationElement,
+            selectedSourceElement.value,
+            selectedDestinationElement.value,
             relationshipDescription,
             technologyChannel,
         );
 
         if (step.trim().length === 0) break;
 
-        dynamicSteps.push(step);
+        dynamicSteps.push(`${stepPosition}: ${step}`);
 
-        const addAnotherStep = await input({
-            message:
-                "Add another step? (yes/no or press Enter for yes, type 'done'/'no' to stop)",
+        const addAnotherStep = await confirm({
+            message: "Add another step?",
+            default: true,
         });
 
-        const normalizedAddAnotherStep = addAnotherStep.trim().toLowerCase();
-        if (
-            normalizedAddAnotherStep === "done" ||
-            normalizedAddAnotherStep === "no" ||
-            normalizedAddAnotherStep === "n"
-        ) {
-            break;
-        }
+        if (!addAnotherStep) break;
     }
 
     return dynamicSteps;
 }
 
 function getDynamicScopeChoices(workspaceScope?: string) {
-    if (workspaceScope === "softwaresystem") {
+    if (workspaceScope === "SoftwareSystem") {
         return [
             { name: "System", value: "system" },
             { name: "Container", value: "container" },
@@ -153,41 +280,21 @@ function getDynamicScopeChoices(workspaceScope?: string) {
     ];
 }
 
-function getSystemContainerChoices(
-    workspaceInfo: Awaited<ReturnType<typeof getWorkspaceJson>>,
-    systemName: string,
-) {
-    const workspaceElements = getAllWorkspaceElements(workspaceInfo, {
-        includeContainers: true,
-        includeComponents: false,
-    });
-
-    return workspaceElements
-        .filter(
-            (element) =>
-                element.systemName === systemName && "containerName" in element,
-        )
-        .map((element) => ({
-            name: element.name,
-            value: element.name,
-        }));
-}
-
 // TODO: Other types of views
-// - Dynamic
 // - Filtered
+// // - Dynamic
 // // - System landscape
 // // - Deployment
 const generator: GeneratorDefinition<ViewAnswers> = {
     name: Elements.View,
     description: "Create a new view",
     questions: async (generator) => {
-        const workspaceInfo = await getWorkspaceJson(
-            getWorkspacePath(generator.destPath),
-        );
+        const workspaceFolder = getWorkspacePath(generator.destPath);
+        const workspaceInfo = await getWorkspaceJson(workspaceFolder);
 
         const workspaceScope =
-            workspaceInfo?.configuration.scope?.toLowerCase();
+            normalizeWorkspaceScope(workspaceInfo?.configuration.scope) ??
+            (await getWorkspaceDslScope(workspaceFolder));
 
         const viewType = await select<string>({
             name: "viewType",
@@ -230,9 +337,9 @@ const generator: GeneratorDefinition<ViewAnswers> = {
 
         const dynamicScopeElement =
             dynamicScope === "container"
-                ? containerName
+                ? getDslIdentifier(workspaceInfo, containerName ?? "")
                 : dynamicScope === "system"
-                  ? systemName
+                  ? getDslIdentifier(workspaceInfo, systemName ?? "")
                   : undefined;
 
         const viewName = await input({
@@ -241,6 +348,7 @@ const generator: GeneratorDefinition<ViewAnswers> = {
             validate: chainValidators(
                 stringEmpty,
                 validateDuplicatedViews(workspaceInfo),
+                validateDuplicatedViewFile(workspaceFolder),
             )(),
         });
 
@@ -251,7 +359,14 @@ const generator: GeneratorDefinition<ViewAnswers> = {
         });
 
         const dynamicSteps =
-            viewType === "dynamic" ? await collectDynamicSteps() : undefined;
+            viewType === "dynamic"
+                ? await collectDynamicSteps(
+                      workspaceInfo,
+                      (dynamicScope as DynamicScope) ?? "workspace",
+                      systemName,
+                      containerName,
+                  )
+                : undefined;
 
         const instanceDescription =
             viewType === "deployment"
@@ -297,7 +412,7 @@ const generator: GeneratorDefinition<ViewAnswers> = {
             templateFile: "templates/environments/deployment.hbs",
         } as AddAction<ViewAnswers>,
         {
-            when: whenViewType("landscape"),
+            skip: skipUnlessViewType("landscape"),
             type: "add",
             skipIfExists: true,
             path: "architecture/views/{{kebabCase viewName}}.dsl",

--- a/lib/templates/bundle.ts
+++ b/lib/templates/bundle.ts
@@ -27,6 +27,7 @@ import themeTemplate from "./theme.hbs";
 import viewsComponent from "./views/component.hbs";
 import viewsContainer from "./views/container.hbs";
 import viewsDeployment from "./views/deployment.hbs";
+import viewsDynamic from "./views/dynamic.hbs";
 import viewsLandscape from "./views/landscape.hbs";
 import viewsSystem from "./views/system.hbs";
 import workspace from "./workspace.hbs";
@@ -68,6 +69,7 @@ const templatesMap = new Map([
     ["templates/views/component.hbs", viewsComponent],
     ["templates/views/container.hbs", viewsContainer],
     ["templates/views/deployment.hbs", viewsDeployment],
+    ["templates/views/dynamic.hbs", viewsDynamic],
     ["templates/views/landscape.hbs", viewsLandscape],
     ["templates/views/system.hbs", viewsSystem],
     ["templates/workspace.hbs", workspace],

--- a/lib/templates/views/dynamic.hbs
+++ b/lib/templates/views/dynamic.hbs
@@ -1,0 +1,11 @@
+dynamic {{#if (eq dynamicScopeType "workspace")}}*{{else}}{{pascalCase (removeSpaces dynamicScopeElement)}}{{/if}} "{{pascalCase (removeSpaces viewName)}}" {
+    description "{{{viewDescription}}}. ${AUTHOR}"
+{{#if dynamicSteps}}
+{{#each dynamicSteps}}
+    {{{this}}}
+{{/each}}
+{{else}}
+    // Add sequential steps here
+{{/if}}
+    autoLayout lr
+}

--- a/lib/templates/views/dynamic.hbs
+++ b/lib/templates/views/dynamic.hbs
@@ -1,4 +1,4 @@
-dynamic {{#if (eq dynamicScopeType "workspace")}}*{{else}}{{pascalCase (removeSpaces dynamicScopeElement)}}{{/if}} "{{pascalCase (removeSpaces viewName)}}" {
+dynamic {{#if (eq dynamicScopeType "workspace")}}*{{else}}{{{dynamicScopeElement}}}{{/if}} "{{pascalCase (removeSpaces viewName)}}" {
     description "{{{viewDescription}}}. ${AUTHOR}"
 {{#if dynamicSteps}}
 {{#each dynamicSteps}}

--- a/lib/utils/questions/system.ts
+++ b/lib/utils/questions/system.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { kebabCase } from "change-case";
 import { input, select } from "../prompts";
 import type { StructurizrWorkspace } from "../workspace";
-import { getWorkspacePath } from "../workspace";
+import { getWorkspacePath, normalizeWorkspaceScope } from "../workspace";
 
 type SoftwareElement = StructurizrWorkspace["model"]["people"][number];
 type SoftwareSystem = StructurizrWorkspace["model"]["softwareSystems"][number];
@@ -86,14 +86,15 @@ export function resolveSystemQuestion(
     const workspaceInfo = typeof workspace !== "string" && workspace;
 
     if (workspaceInfo) {
-        const workspaceScope =
-            workspaceInfo?.configuration.scope?.toLowerCase();
+        const workspaceScope = normalizeWorkspaceScope(
+            workspaceInfo?.configuration.scope,
+        );
 
         const systems = (workspaceInfo.model?.softwareSystems ?? [])
             .filter((system) => !system.tags.split(",").includes("External"))
             .map((system) => ({ name: system.name, value: system.name }));
 
-        if (workspaceScope === "softwaresystem") {
+        if (workspaceScope === "SoftwareSystem") {
             return Promise.resolve(systems[0].value);
         }
 

--- a/lib/utils/questions/validators.test.ts
+++ b/lib/utils/questions/validators.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { StructurizrWorkspace } from "../workspace";
 import {
     chainValidators,
     duplicatedSystemName,
     validateDuplicatedElements,
+    validateDuplicatedViewFile,
     validateDuplicatedViews,
 } from "./validators";
 
@@ -147,6 +151,41 @@ describe("validators", () => {
                 'View with name "SomeView" already exists.',
             );
             expect(loadedValidator?.("Not Duplicated")).toEqual(true);
+        });
+    });
+
+    describe("validateDuplicatedViewFile", () => {
+        test("returns true when workspaceFolder is undefined", async () => {
+            const result =
+                await validateDuplicatedViewFile(undefined)("MyView");
+            expect(result).toBe(true);
+        });
+
+        test("returns true when view file does not exist", async () => {
+            const tmpFolder = join(tmpdir(), `scfz-test-${Date.now()}`);
+            await mkdir(join(tmpFolder, "views"), { recursive: true });
+
+            try {
+                const result =
+                    await validateDuplicatedViewFile(tmpFolder)("MyView");
+                expect(result).toBe(true);
+            } finally {
+                await rm(tmpFolder, { recursive: true, force: true });
+            }
+        });
+
+        test("returns error message when view file already exists", async () => {
+            const tmpFolder = join(tmpdir(), `scfz-test-${Date.now()}`);
+            await mkdir(join(tmpFolder, "views"), { recursive: true });
+            await writeFile(join(tmpFolder, "views", "my-view.dsl"), "");
+
+            try {
+                const result =
+                    await validateDuplicatedViewFile(tmpFolder)("MyView");
+                expect(result).toBe('View with name "MyView" already exists.');
+            } finally {
+                await rm(tmpFolder, { recursive: true, force: true });
+            }
         });
     });
 });

--- a/lib/utils/questions/validators.ts
+++ b/lib/utils/questions/validators.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+import { file } from "bun";
 import { kebabCase, pascalCase } from "change-case";
 import { removeSpaces } from "../handlebars";
 import type { StructurizrWorkspace } from "../workspace";
@@ -91,6 +93,23 @@ export const validateDuplicatedViews =
         const viewName = pascalCase(removeSpaces(input));
         if (systemViews.includes(viewName)) {
             return `View with name "${viewName}" already exists.`;
+        }
+
+        return true;
+    };
+
+export const validateDuplicatedViewFile =
+    (workspaceFolder: string | undefined): Validator =>
+    async (input: string) => {
+        if (!workspaceFolder) return true;
+
+        const viewFilePath = join(
+            workspaceFolder,
+            "views",
+            `${kebabCase(input)}.dsl`,
+        );
+        if (await file(viewFilePath).exists()) {
+            return `View with name "${input}" already exists.`;
         }
 
         return true;

--- a/lib/utils/questions/view.test.ts
+++ b/lib/utils/questions/view.test.ts
@@ -1,0 +1,839 @@
+import { describe, expect, test } from "bun:test";
+import { Separator } from "../prompts";
+import {
+    normalizeWorkspaceScope,
+    type StructurizrWorkspace,
+} from "../workspace";
+import type { StepElementChoice, ViewElement } from "./view";
+import {
+    getDynamicStepElementChoices,
+    getRelationshipsForElement,
+} from "./view";
+
+describe("getRelationshipsForElement", () => {
+    test("returns elements with outgoing relationship from source", () => {
+        const source: ViewElement = {
+            id: "source-1",
+            name: "Source",
+            relationships: [
+                { sourceId: "source-1", destinationId: "target-1" },
+            ],
+        };
+        const candidates: ViewElement[] = [
+            { id: "target-1", name: "Target One" },
+            { id: "target-2", name: "Target Two" },
+        ];
+
+        const result = getRelationshipsForElement(source, candidates);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe("target-1");
+    });
+
+    test("does not return elements that only have an incoming relationship to source", () => {
+        const source: ViewElement = {
+            id: "source-1",
+            name: "Source",
+        };
+        const candidates: ViewElement[] = [
+            {
+                id: "caller-1",
+                name: "Caller",
+                relationships: [
+                    { sourceId: "caller-1", destinationId: "source-1" },
+                ],
+            },
+            { id: "unrelated-1", name: "Unrelated" },
+        ];
+
+        const result = getRelationshipsForElement(source, candidates);
+
+        expect(result).toHaveLength(0);
+    });
+
+    test("returns both outgoing and incoming partners as union", () => {
+        const source: ViewElement = {
+            id: "source-1",
+            name: "Source",
+            relationships: [
+                { sourceId: "source-1", destinationId: "outgoing-1" },
+            ],
+        };
+        const candidates: ViewElement[] = [
+            { id: "outgoing-1", name: "Outgoing Target" },
+            {
+                id: "incoming-1",
+                name: "Incoming Caller",
+                relationships: [
+                    { sourceId: "incoming-1", destinationId: "source-1" },
+                ],
+            },
+            { id: "unrelated-1", name: "Unrelated" },
+        ];
+
+        const result = getRelationshipsForElement(source, candidates);
+
+        expect(result).toHaveLength(1);
+        const resultIds = result.map((e) => e.id);
+        expect(resultIds).toContain("outgoing-1");
+        expect(resultIds).not.toContain("incoming-1");
+    });
+
+    test("excludes elements with no relationship to source", () => {
+        const source: ViewElement = {
+            id: "source-1",
+            name: "Source",
+            relationships: [
+                { sourceId: "source-1", destinationId: "target-1" },
+            ],
+        };
+        const candidates: ViewElement[] = [
+            { id: "target-1", name: "Target" },
+            { id: "unrelated-1", name: "Unrelated One" },
+            { id: "unrelated-2", name: "Unrelated Two" },
+        ];
+
+        const result = getRelationshipsForElement(source, candidates);
+
+        const resultIds = result.map((e) => e.id);
+        expect(resultIds).not.toContain("unrelated-1");
+        expect(resultIds).not.toContain("unrelated-2");
+    });
+
+    test("returns empty array when source has no relationships and no candidates point to source", () => {
+        const source: ViewElement = {
+            id: "source-1",
+            name: "Source",
+        };
+        const candidates: ViewElement[] = [
+            { id: "candidate-1", name: "Candidate One" },
+            { id: "candidate-2", name: "Candidate Two" },
+        ];
+
+        const result = getRelationshipsForElement(source, candidates);
+
+        expect(result).toHaveLength(0);
+    });
+
+    test("does not include source element itself in results", () => {
+        const source: ViewElement = {
+            id: "source-1",
+            name: "Source",
+            relationships: [
+                { sourceId: "source-1", destinationId: "target-1" },
+            ],
+        };
+        const candidates: ViewElement[] = [
+            source,
+            { id: "target-1", name: "Target" },
+        ];
+
+        const result = getRelationshipsForElement(source, candidates);
+
+        const resultIds = result.map((e) => e.id);
+        expect(resultIds).not.toContain("source-1");
+        expect(resultIds).toContain("target-1");
+    });
+});
+
+function makeWorkspace(
+    overrides: Partial<StructurizrWorkspace["model"]> = {},
+): StructurizrWorkspace {
+    return {
+        id: 1,
+        name: "Test",
+        description: "",
+        lastModifiedDate: "",
+        properties: {},
+        configuration: {
+            scope: "SoftwareSystem",
+            styles: {},
+            branding: {},
+            terminology: {},
+        },
+        documentation: { sections: [], images: [] },
+        views: {
+            systemLandscapeViews: [],
+            systemContextViews: [],
+            configuration: {} as never,
+        },
+        model: {
+            people: [],
+            softwareSystems: [],
+            deploymentNodes: [],
+            ...overrides,
+        },
+    };
+}
+
+const defaultWorkspace = makeWorkspace({
+    people: [
+        {
+            id: "p1",
+            name: "User",
+            tags: "Element,Person",
+            description: "",
+            documentation: { sections: [], images: [] },
+            properties: {},
+            relationships: [],
+        },
+    ],
+    softwareSystems: [
+        {
+            id: "ss1",
+            name: "My System",
+            tags: "Element,Software System",
+            description: "",
+            location: "Internal",
+            documentation: { sections: [], images: [] },
+            properties: {},
+            relationships: [],
+            containers: [
+                {
+                    id: "c1",
+                    name: "My Container",
+                    tags: "Element,Container",
+                    technology: "Node",
+                    description: "",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    components: [
+                        {
+                            id: "comp1",
+                            name: "My Component",
+                            tags: "Element,Component",
+                            technology: "TS",
+                            description: "",
+                            documentation: { sections: [], images: [] },
+                            properties: {},
+                            relationships: [],
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            id: "ss2",
+            name: "External",
+            tags: "Element,Software System,External",
+            description: "",
+            location: "External",
+            documentation: { sections: [], images: [] },
+            properties: {},
+            relationships: [],
+            containers: [],
+        },
+    ],
+    deploymentNodes: [],
+});
+
+function isStepElementChoice(
+    value: StepElementChoice | Separator,
+): value is StepElementChoice {
+    return !(value instanceof Separator);
+}
+
+describe("getDynamicStepElementChoices", () => {
+    test("workspace scope returns all elements", () => {
+        const result = getDynamicStepElementChoices(
+            defaultWorkspace,
+            "workspace",
+        );
+        const nonSeparatorResults = result.filter(isStepElementChoice);
+
+        expect(nonSeparatorResults.length).toBe(5);
+    });
+
+    test("workspace scope includes separators", () => {
+        const result = getDynamicStepElementChoices(
+            defaultWorkspace,
+            "workspace",
+        );
+
+        expect(result.some((value) => value instanceof Separator)).toBe(true);
+    });
+
+    test("system scope includes person regardless of systemName", () => {
+        const result = getDynamicStepElementChoices(
+            defaultWorkspace,
+            "system",
+            "SomeSystem",
+        );
+
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "p1",
+            ),
+        ).toBe(true);
+    });
+
+    test("system scope includes separators", () => {
+        const result = getDynamicStepElementChoices(
+            defaultWorkspace,
+            "system",
+            "SomeSystem",
+        );
+
+        expect(result.some((value) => value instanceof Separator)).toBe(true);
+    });
+
+    test("system scope includes external system regardless of systemName", () => {
+        const workspace = makeWorkspace({
+            people: [],
+            softwareSystems: [
+                {
+                    id: "ext1",
+                    name: "External",
+                    tags: "Element,Software System,External",
+                    description: "",
+                    location: "External",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [],
+                },
+            ],
+            deploymentNodes: [],
+        });
+
+        const result = getDynamicStepElementChoices(
+            workspace,
+            "system",
+            "SomeSystem",
+        );
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "ext1",
+            ),
+        ).toBe(true);
+    });
+
+    test("system scope excludes scoped system by name", () => {
+        const workspace = makeWorkspace({
+            people: [],
+            softwareSystems: [
+                {
+                    id: "ss1",
+                    name: "My System",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [],
+                },
+                {
+                    id: "ss2",
+                    name: "Other System",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [],
+                },
+            ],
+            deploymentNodes: [],
+        });
+
+        const result = getDynamicStepElementChoices(
+            workspace,
+            "system",
+            "My System",
+        );
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "ss1",
+            ),
+        ).toBe(false);
+    });
+
+    test("system scope excludes scoped system from results", () => {
+        const workspace = makeWorkspace({
+            people: [],
+            softwareSystems: [
+                {
+                    id: "ss1",
+                    name: "MySystem",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [],
+                },
+                {
+                    id: "ss2",
+                    name: "OtherSystem",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [],
+                },
+            ],
+            deploymentNodes: [],
+        });
+
+        const result = getDynamicStepElementChoices(
+            workspace,
+            "system",
+            "MySystem",
+        );
+
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.name === "MySystem",
+            ),
+        ).toBe(false);
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.name === "OtherSystem",
+            ),
+        ).toBe(true);
+    });
+
+    test("system scope includes non-matching system", () => {
+        const workspace = makeWorkspace({
+            people: [],
+            softwareSystems: [
+                {
+                    id: "ss1",
+                    name: "My System",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [],
+                },
+                {
+                    id: "ss2",
+                    name: "Other System",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [],
+                },
+            ],
+            deploymentNodes: [],
+        });
+
+        const result = getDynamicStepElementChoices(
+            workspace,
+            "system",
+            "My System",
+        );
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "ss2",
+            ),
+        ).toBe(true);
+    });
+
+    test("system scope returns containers whose systemName matches", () => {
+        const workspace = makeWorkspace({
+            people: [],
+            softwareSystems: [
+                {
+                    id: "ss1",
+                    name: "My System",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [
+                        {
+                            id: "c1",
+                            name: "API",
+                            tags: "Element,Container",
+                            technology: "Node",
+                            description: "",
+                            documentation: { sections: [], images: [] },
+                            properties: {},
+                            relationships: [],
+                            components: [],
+                        },
+                    ],
+                },
+                {
+                    id: "ss2",
+                    name: "Other System",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [
+                        {
+                            id: "c2",
+                            name: "DB",
+                            tags: "Element,Container",
+                            technology: "Postgres",
+                            description: "",
+                            documentation: { sections: [], images: [] },
+                            properties: {},
+                            relationships: [],
+                            components: [],
+                        },
+                    ],
+                },
+            ],
+            deploymentNodes: [],
+        });
+
+        const result = getDynamicStepElementChoices(
+            workspace,
+            "system",
+            "My System",
+        );
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "c1",
+            ),
+        ).toBe(true);
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "c2",
+            ),
+        ).toBe(false);
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "comp1",
+            ),
+        ).toBe(false);
+    });
+
+    test("system scope excludes components even when they belong to the matched system", () => {
+        const workspace = makeWorkspace({
+            people: [],
+            softwareSystems: [
+                {
+                    id: "ss1",
+                    name: "My System",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [
+                        {
+                            id: "c1",
+                            name: "My Container",
+                            tags: "Element,Container",
+                            technology: "Node",
+                            description: "",
+                            documentation: { sections: [], images: [] },
+                            properties: {},
+                            relationships: [],
+                            components: [
+                                {
+                                    id: "comp1",
+                                    name: "Match Component",
+                                    tags: "Element,Component",
+                                    technology: "TS",
+                                    description: "",
+                                    documentation: { sections: [], images: [] },
+                                    properties: {},
+                                    relationships: [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            deploymentNodes: [],
+        });
+
+        const result = getDynamicStepElementChoices(
+            workspace,
+            "system",
+            "My System",
+        );
+
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "comp1",
+            ),
+        ).toBe(false);
+    });
+
+    test("container scope includes person regardless of scope constraints", () => {
+        const workspace = defaultWorkspace;
+
+        const result = getDynamicStepElementChoices(
+            workspace,
+            "container",
+            "SomeSystem",
+            "SomeContainer",
+        );
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "p1",
+            ),
+        ).toBe(true);
+    });
+
+    test("container scope includes separators when components exist", () => {
+        const workspace = makeWorkspace({
+            people: [],
+            softwareSystems: [
+                {
+                    id: "ss1",
+                    name: "My System",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [
+                        {
+                            id: "c1",
+                            name: "My Container",
+                            tags: "Element,Container",
+                            technology: "Node",
+                            description: "",
+                            documentation: { sections: [], images: [] },
+                            properties: {},
+                            relationships: [],
+                            components: [
+                                {
+                                    id: "comp1",
+                                    name: "Match Component",
+                                    tags: "Element,Component",
+                                    technology: "TS",
+                                    description: "",
+                                    documentation: { sections: [], images: [] },
+                                    properties: {},
+                                    relationships: [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            deploymentNodes: [],
+        });
+
+        const result = getDynamicStepElementChoices(
+            workspace,
+            "container",
+            "My System",
+            "My Container",
+        );
+
+        expect(result.some((value) => value instanceof Separator)).toBe(true);
+    });
+
+    test("container scope returns component where systemName and containerName both match", () => {
+        const workspace = makeWorkspace({
+            people: [],
+            softwareSystems: [
+                {
+                    id: "ss1",
+                    name: "My System",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [
+                        {
+                            id: "c1",
+                            name: "My Container",
+                            tags: "Element,Container",
+                            technology: "Node",
+                            description: "",
+                            documentation: { sections: [], images: [] },
+                            properties: {},
+                            relationships: [],
+                            components: [
+                                {
+                                    id: "comp1",
+                                    name: "Match Component",
+                                    tags: "Element,Component",
+                                    technology: "TS",
+                                    description: "",
+                                    documentation: { sections: [], images: [] },
+                                    properties: {},
+                                    relationships: [],
+                                },
+                            ],
+                        },
+                        {
+                            id: "c2",
+                            name: "Other Container",
+                            tags: "Element,Container",
+                            technology: "Node",
+                            description: "",
+                            documentation: { sections: [], images: [] },
+                            properties: {},
+                            relationships: [],
+                            components: [
+                                {
+                                    id: "comp2",
+                                    name: "Other Component",
+                                    tags: "Element,Component",
+                                    technology: "TS",
+                                    description: "",
+                                    documentation: { sections: [], images: [] },
+                                    properties: {},
+                                    relationships: [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            deploymentNodes: [],
+        });
+
+        const result = getDynamicStepElementChoices(
+            workspace,
+            "container",
+            "My System",
+            "My Container",
+        );
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "comp1",
+            ),
+        ).toBe(true);
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "comp2",
+            ),
+        ).toBe(false);
+    });
+
+    test("container scope excludes containers (only returns components)", () => {
+        const workspace = makeWorkspace({
+            people: [],
+            softwareSystems: [
+                {
+                    id: "ss1",
+                    name: "My System",
+                    tags: "Element,Software System",
+                    description: "",
+                    location: "Internal",
+                    documentation: { sections: [], images: [] },
+                    properties: {},
+                    relationships: [],
+                    containers: [
+                        {
+                            id: "c1",
+                            name: "My Container",
+                            tags: "Element,Container",
+                            technology: "Node",
+                            description: "",
+                            documentation: { sections: [], images: [] },
+                            properties: {},
+                            relationships: [],
+                            components: [
+                                {
+                                    id: "comp1",
+                                    name: "A Component",
+                                    tags: "Element,Component",
+                                    technology: "TS",
+                                    description: "",
+                                    documentation: { sections: [], images: [] },
+                                    properties: {},
+                                    relationships: [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            deploymentNodes: [],
+        });
+
+        const result = getDynamicStepElementChoices(
+            workspace,
+            "container",
+            "My System",
+            "My Container",
+        );
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "c1",
+            ),
+        ).toBe(false);
+        expect(
+            result.some(
+                (e): e is StepElementChoice =>
+                    isStepElementChoice(e) && e._element.id === "comp1",
+            ),
+        ).toBe(true);
+    });
+});
+
+describe("normalizeWorkspaceScope", () => {
+    test("returns undefined for undefined", () => {
+        expect(normalizeWorkspaceScope(undefined)).toBeUndefined();
+    });
+
+    test("returns undefined for empty string", () => {
+        expect(normalizeWorkspaceScope("")).toBeUndefined();
+    });
+
+    test("normalizes lowercase softwaresystem", () => {
+        expect(normalizeWorkspaceScope("softwaresystem")).toBe(
+            "SoftwareSystem",
+        );
+    });
+
+    test("normalizes mixed case SoftwareSystem", () => {
+        expect(normalizeWorkspaceScope("SoftwareSystem")).toBe(
+            "SoftwareSystem",
+        );
+    });
+
+    test("normalizes spaced software system", () => {
+        expect(normalizeWorkspaceScope("software system")).toBe(
+            "SoftwareSystem",
+        );
+    });
+
+    test("normalizes lowercase landscape", () => {
+        expect(normalizeWorkspaceScope("landscape")).toBe("Landscape");
+    });
+
+    test("normalizes mixed case Landscape", () => {
+        expect(normalizeWorkspaceScope("Landscape")).toBe("Landscape");
+    });
+
+    test("returns undefined for unknown values", () => {
+        expect(normalizeWorkspaceScope("unknown")).toBeUndefined();
+    });
+});

--- a/lib/utils/questions/view.test.ts
+++ b/lib/utils/questions/view.test.ts
@@ -51,7 +51,7 @@ describe("getRelationshipsForElement", () => {
         expect(result).toHaveLength(0);
     });
 
-    test("returns both outgoing and incoming partners as union", () => {
+    test("returns only outgoing relationship targets, excluding incoming-only callers", () => {
         const source: ViewElement = {
             id: "source-1",
             name: "Source",

--- a/lib/utils/questions/view.ts
+++ b/lib/utils/questions/view.ts
@@ -1,0 +1,160 @@
+import { Elements, elementTypeByTags, labelElementByTags } from "../labels";
+import { type Separator, separator } from "../prompts";
+import type { getWorkspaceJson, StructurizrWorkspace } from "../workspace";
+import { getAllWorkspaceElements } from "./system";
+
+export type ViewElement = {
+    id: string;
+    name: string;
+    tags?: string;
+    systemName?: string;
+    containerName?: string;
+    position?: number;
+    properties?: { "structurizr.dsl.identifier"?: string };
+    relationships?: { sourceId: string; destinationId: string }[];
+};
+
+export type StepElementChoice = {
+    name: string;
+    value: string;
+    _element: ViewElement;
+};
+
+export function getSystemContainerChoices(
+    workspaceInfo: Awaited<ReturnType<typeof getWorkspaceJson>>,
+    systemName: string,
+) {
+    const workspaceElements = getAllWorkspaceElements(workspaceInfo, {
+        includeContainers: true,
+        includeComponents: false,
+    });
+
+    return workspaceElements
+        .filter(
+            (element) =>
+                element.systemName === systemName &&
+                elementTypeByTags(element.tags) === Elements.Container,
+        )
+        .map((element) => ({
+            name: element.name,
+            value: element.name,
+        }));
+}
+
+export type DynamicScope = "workspace" | "system" | "container";
+
+export function getDynamicStepElementChoices(
+    workspaceInfo: StructurizrWorkspace | undefined,
+    dynamicScope: DynamicScope,
+    systemName?: string,
+    containerName?: string,
+): Array<StepElementChoice | Separator> {
+    const filteredElements = getAllWorkspaceElements(workspaceInfo, {
+        includeContainers: true,
+        includeComponents: true,
+        includeDeploymentNodes: false,
+    }).filter((element) => {
+        const elementType = elementTypeByTags(element.tags);
+
+        if (dynamicScope === "workspace") return true;
+
+        if (
+            elementType === Elements.Person ||
+            elementType === Elements.ExternalSystem
+        ) {
+            return true;
+        }
+
+        if (dynamicScope === "system") {
+            if (elementType === Elements.System) {
+                return element.name !== systemName;
+            }
+
+            if (elementType === Elements.Container) {
+                return element.systemName === systemName;
+            }
+
+            return false;
+        }
+
+        if (dynamicScope === "container") {
+            return (
+                elementType === Elements.Component &&
+                element.systemName === systemName &&
+                element.containerName === containerName
+            );
+        }
+
+        return false;
+    });
+
+    const people = filteredElements.filter(
+        (el) => elementTypeByTags(el.tags) === Elements.Person,
+    );
+    const externalSystems = filteredElements.filter(
+        (el) => elementTypeByTags(el.tags) === Elements.ExternalSystem,
+    );
+    const softwareSystems = filteredElements.filter(
+        (el) => elementTypeByTags(el.tags) === Elements.System,
+    );
+    const containers = filteredElements.filter(
+        (el) => elementTypeByTags(el.tags) === Elements.Container,
+    );
+    const components = filteredElements.filter(
+        (el) => elementTypeByTags(el.tags) === Elements.Component,
+    );
+
+    const mapToChoice = (
+        element: (typeof filteredElements)[number],
+    ): StepElementChoice => {
+        const value =
+            element.properties?.["structurizr.dsl.identifier"] ?? element.name;
+
+        const hierarchy = [
+            element.systemName,
+            element.containerName,
+            element.name,
+        ]
+            .filter(Boolean)
+            .join("/");
+
+        return {
+            name: `${labelElementByTags(element.tags)} ${hierarchy}`,
+            value,
+            _element: element as ViewElement,
+        };
+    };
+
+    const mappedComponents = components.map(mapToChoice);
+    const mappedContainers = containers.map(mapToChoice);
+    const mappedSoftwareSystems = softwareSystems.map(mapToChoice);
+    const mappedExternalSystems = externalSystems.map(mapToChoice);
+    const mappedPeople = people.map(mapToChoice);
+
+    return [
+        separator("Components", mappedComponents),
+        ...mappedComponents,
+        separator("Containers", mappedContainers),
+        ...mappedContainers,
+        separator("Systems", mappedSoftwareSystems),
+        ...mappedSoftwareSystems,
+        separator("External Systems", mappedExternalSystems),
+        ...mappedExternalSystems,
+        separator("People", mappedPeople),
+        ...mappedPeople,
+    ].filter((x): x is StepElementChoice | Separator => x !== undefined);
+}
+
+export function getRelationshipsForElement(
+    sourceElement: ViewElement,
+    candidateElements: ViewElement[],
+): ViewElement[] {
+    const outgoingPartnerIds = new Set(
+        sourceElement.relationships?.map(
+            (relationship) => relationship.destinationId,
+        ) ?? [],
+    );
+    return candidateElements.filter((element) =>
+        outgoingPartnerIds.has(element.id),
+    );
+}

--- a/lib/utils/workspace.ts
+++ b/lib/utils/workspace.ts
@@ -107,7 +107,22 @@ type Configuration = {
     branding: Item;
     styles: Item;
     terminology: Item;
-    scope?: "Landscape" | "SoftwareSystem";
+    scope?: string;
+};
+
+export type WorkspaceScope = "Landscape" | "SoftwareSystem";
+
+export const normalizeWorkspaceScope = (
+    scope: string | undefined,
+): WorkspaceScope | undefined => {
+    if (!scope) return undefined;
+
+    const normalizedScope = scope.toLowerCase().replace(/\s+/g, "");
+
+    if (normalizedScope === "softwaresystem") return "SoftwareSystem";
+    if (normalizedScope === "landscape") return "Landscape";
+
+    return undefined;
 };
 
 export type StructurizrWorkspace = {
@@ -161,16 +176,14 @@ export const getWorkspaceJson = async (
 
 export const getWorkspaceDslScope = async (
     workspaceFolder: string | undefined,
-): Promise<"SoftwareSystem" | "Landscape" | undefined> => {
+): Promise<WorkspaceScope | undefined> => {
     if (!workspaceFolder) return undefined;
     const dslFile = file(join(workspaceFolder, "workspace.dsl"));
     if (dslFile.size === 0) return undefined;
     const content = await dslFile.text();
     const match = content.match(/scope\s+(softwaresystem|landscape)/i);
     if (!match) return undefined;
-    return match[1].toLowerCase() === "softwaresystem"
-        ? "SoftwareSystem"
-        : "Landscape";
+    return normalizeWorkspaceScope(match[1]);
 };
 
 export type WorkspaceElement = {

--- a/test/workspace.ts
+++ b/test/workspace.ts
@@ -1,9 +1,12 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { spawn } from "bun";
 import { keypress, loop } from "./io";
 
 export const createWorkspaceFromCLI = async (
     folder: string,
     scope = "landscape",
+    workspaceJson?: object,
 ) => {
     const proc = spawn(["dist/scfz", "--dest", folder, "--export"], {
         stdin: "pipe",
@@ -32,6 +35,14 @@ export const createWorkspaceFromCLI = async (
 
     const response = await new Response(proc.stdout).text();
     console.log(`Scaffoldizr Output:\n${response}`);
+
+    if (workspaceJson) {
+        await mkdir(join(folder, "architecture"), { recursive: true });
+        await writeFile(
+            join(folder, "architecture/workspace.json"),
+            JSON.stringify(workspaceJson, null, 2),
+        );
+    }
 
     return response;
 };


### PR DESCRIPTION
## Summary

Adds an interactive **Dynamic View** generator to Scaffoldizr, enabling users to document runtime behaviour via Structurizr DSL dynamic views.

## What's included

### Element selection driven by `workspace.json`
- No free-text identifiers — all source/destination elements are resolved from the parsed workspace
- Scope options: `workspace`, `system`, `container`
- Choices grouped with `Separator` headings: **Components / Containers / Systems / External Systems / People**

### Relationship guardrails
- Destination choices are filtered to the outgoing relationships of the selected source element
- Prevents invalid pairs that Structurizr would reject

### DSL identifier support
- Uses the `structurizr.dsl.identifier` property as the DSL output identifier when present

### Step collection UX
- Numbered steps (step 1, step 2, …)
- Repeated `--step-N` CLI flags produce parallel steps sharing the same number
- Step continuation: Inquirer `confirm()` prompt ("Add another step?")

### Duplicate view name validation
- File-based check: rejects view names whose `.dsl` file already exists in the views directory
- Workspace-based check: rejects names already present in `workspace.json`

## Test coverage
- **175 unit tests** across validators, view question helpers, workspace utilities
- **E2E coverage** in `scfz-non-interactive.test.ts` and `scfz-softwaresystem.test.ts`

## Commits
| # | Commit | Scope |
|---|--------|-------|
| 1 | `feat(workspace)` | Extend workspace types + element query helpers |
| 2 | `test(workspace)` | Shared test workspace fixture |
| 3 | `feat(validators)` | Duplicate view file validation |
| 4 | `feat(questions)` | Dynamic view step element choice helpers (175 tests) |
| 5 | `feat(templates)` | Dynamic view DSL Handlebars template |
| 6 | `feat(generators)` | Dynamic view generator with step collection |
| 7 | `test(e2e)` | E2E coverage for dynamic view |
| 8 | `chore(architecture)` | Update workspace.json with dynamic view records |
