### PR TITLE
feat: configurable Structurizr workspace max size and version bump to 2026.06.28

### DIFF
--- a/.agents/skills/scaffoldizr/extra/CLI.md
+++ b/.agents/skills/scaffoldizr/extra/CLI.md
@@ -15,10 +15,10 @@ Refer to the [Structurizr commands reference](https://docs.structurizr.com/comma
 ./architecture/scripts/export.ps1
 ```
 
-Or run the Docker command directly (replace `2026.05.22` with `$STCTZR_VERSION` if you need a different version):
+Or run the Docker command directly (replace `2026.06.28` with `$STCTZR_VERSION` if you need a different version):
 
 ```bash
-docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.05.22 export -w /usr/local/structurizr/workspace.dsl -f json
+docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.06.28 export -w /usr/local/structurizr/workspace.dsl -f json
 ```
 
 ## List elements within a workspace
@@ -26,7 +26,7 @@ docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structur
 You can list all the elements within a Structurizr workspace by running the following command from the workspace root (the folder containing `workspace.dsl`):
 
 ```bash
-docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.05.22 list -w /usr/local/structurizr/workspace.dsl
+docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.06.28 list -w /usr/local/structurizr/workspace.dsl
 ```
 
 The command will output the current elements in the following format:
@@ -43,7 +43,7 @@ The command will output the current elements in the following format:
 Whenever changes are made to the DSL files, it's important to validate that the workspace is still valid and there are no errors. To do so, run the following command:
 
 ```bash
-docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.05.22 validate -w /usr/local/structurizr/workspace.dsl
+docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.06.28 validate -w /usr/local/structurizr/workspace.dsl
 ```
 
 ### Inspect violations
@@ -51,5 +51,5 @@ docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structur
 The inspect command allows you to inspect a JSON/DSL workspace via the workspace inspection feature. The return code indicates the number of violations that were shown. To run the inspect command:
 
 ```bash
-docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.05.22 inspect -w /usr/local/structurizr/workspace.dsl
+docker run --rm -v {workspace-path}/architecture:/usr/local/structurizr structurizr/structurizr:2026.06.28 inspect -w /usr/local/structurizr/workspace.dsl
 ```

--- a/architecture/docs/03-usage.md
+++ b/architecture/docs/03-usage.md
@@ -143,6 +143,29 @@ Pushes the compiled `workspace.json` to a remote Structurizr instance using the 
 
 For all available Structurizr CLI commands, see the [Structurizr commands reference](https://docs.structurizr.com/commands).
 
+### Script Environment Variables
+
+The generated scripts read the following optional environment variables. Unlike `.env-arch`, these are not read from a file — export them in your shell (or set them inline) when you need to override a default.
+
+| Variable | Used by | Default | Description |
+| :------- | :------ | :------ | :---------- |
+| `STCTZR_VERSION` | all scripts | The version locked by your `scfz` release | Structurizr Docker image tag to run. |
+| `STCTZR_MAX_WORKSPACE_SIZE` | `run` only | `10MB` | Maximum workspace size the local server will accept. |
+
+```bash
+# Run a different Structurizr image tag
+STCTZR_VERSION=2026.06.28 ./architecture/scripts/run.sh
+
+# Allow a larger workspace
+STCTZR_MAX_WORKSPACE_SIZE=25MB ./architecture/scripts/run.sh
+```
+
+**About the workspace size limit**: Structurizr refuses to load a workspace larger than `structurizr.workspace.maxsize`, which defaults to `1MB` upstream. Because a moderately sized C4 model can exceed that, the generated `run` scripts raise the limit to `10MB` for you. If you see a "workspace too large" error, raise it further with `STCTZR_MAX_WORKSPACE_SIZE`. The value accepts bytes, `KB`, or `MB` — `1048576`, `1024KB`, and `1MB` are equivalent.
+
+This setting applies only to `run.sh` / `run.ps1`. It is enforced by the Structurizr local server, so the `update`, `export`, and `inspect` scripts do not read it — when pushing to a remote instance, the limit that matters is the one configured on that server.
+
+> **Note**: Very large workspaces degrade rendering performance in the browser. Structurizr recommends keeping `workspace.json` under 1–2MB and splitting large landscapes across [multiple workspaces](https://docs.structurizr.com/workspaces) instead of raising the limit indefinitely.
+
 ### .env-arch — Remote Credentials
 
 The `architecture/.env-arch` file holds the authentication credentials required by `update.sh` / `update.ps1`. It is **not committed to version control**.

--- a/architecture/docs/08-migrate.md
+++ b/architecture/docs/08-migrate.md
@@ -41,6 +41,14 @@ Currently, Scaffoldizr includes the following bundled migrations:
     *   `scripts/run.ps1`
     *   `scripts/update.sh`
     *   `scripts/update.ps1`
+3.  **Add standalone scripts**: Pins the locked Structurizr version in the scripts and adds the standalone `export` and `inspect` scripts, so the workspace can be compiled and inspected without the `scfz` tool. In addition to the four scripts above, this adds:
+    *   `scripts/export.sh`
+    *   `scripts/export.ps1`
+    *   `scripts/inspect.sh`
+    *   `scripts/inspect.ps1`
+4.  **Add workspace max size**: Regenerates all eight scripts so they pin the current locked Structurizr version, and raises the local server's maximum workspace size to `10MB` (overridable with `STCTZR_MAX_WORKSPACE_SIZE`). See the "Script Environment Variables" section of the Usage page for details.
+
+Migrations are cumulative and idempotent: only those newer than your workspace's recorded version are applied, and re-running one leaves your files unchanged. Because the script migrations overwrite the generated scripts from the bundled templates, any manual edits you made to files under `scripts/` will be lost — re-apply them after migrating.
 
 ## When to run
 

--- a/architecture/scripts/export.ps1
+++ b/architecture/scripts/export.ps1
@@ -1,5 +1,5 @@
 $docsLocation = Split-Path -Parent $PSScriptRoot
-$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.05.22" }
+$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.06.28" }
 
 Write-Host "Exporting workspace: $docsLocation (structurizr:${version})"
 

--- a/architecture/scripts/export.sh
+++ b/architecture/scripts/export.sh
@@ -2,7 +2,7 @@
 
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 version="${STCTZR_VERSION:-}"
-if [ -z "$version" ]; then version="2026.05.22"; fi
+if [ -z "$version" ]; then version="2026.06.28"; fi
 
 echo "Exporting workspace: ${docs_location} (structurizr:${version})"
 

--- a/architecture/scripts/inspect.ps1
+++ b/architecture/scripts/inspect.ps1
@@ -1,5 +1,5 @@
 $docsLocation = Split-Path -Parent $PSScriptRoot
-$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.05.22" }
+$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.06.28" }
 
 Write-Host "Inspecting workspace: $docsLocation (structurizr:${version})"
 

--- a/architecture/scripts/inspect.sh
+++ b/architecture/scripts/inspect.sh
@@ -2,7 +2,7 @@
 
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 version="${STCTZR_VERSION:-}"
-if [ -z "$version" ]; then version="2026.05.22"; fi
+if [ -z "$version" ]; then version="2026.06.28"; fi
 
 echo "Inspecting workspace: ${docs_location} (structurizr:${version})"
 

--- a/architecture/scripts/run.ps1
+++ b/architecture/scripts/run.ps1
@@ -1,6 +1,6 @@
 $docsLocation = Split-Path -Parent $PSScriptRoot
 $port = if ($args[0]) { $args[0] } else { 8080 }
-$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.05.22" }
+$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.06.28" }
 
 if (-not (Test-Path "$docsLocation\workspace.dsl")) {
     Write-Error "ERROR: workspace.dsl file not found in `"$docsLocation`" folder."

--- a/architecture/scripts/run.ps1
+++ b/architecture/scripts/run.ps1
@@ -1,6 +1,7 @@
 $docsLocation = Split-Path -Parent $PSScriptRoot
 $port = if ($args[0]) { $args[0] } else { 8080 }
 $version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.06.28" }
+$maxWorkspaceSize = if ($env:STCTZR_MAX_WORKSPACE_SIZE) { $env:STCTZR_MAX_WORKSPACE_SIZE } else { "10MB" }
 
 if (-not (Test-Path "$docsLocation\workspace.dsl")) {
     Write-Error "ERROR: workspace.dsl file not found in `"$docsLocation`" folder."
@@ -20,7 +21,7 @@ function Stop-Container {
 Write-Host "Running workspace: $docsLocation on port $port"
 
 try {
-    docker run --rm --name $containerName -p "${port}:8080" -v "${docsLocation}:/usr/local/structurizr" "structurizr/structurizr:${version}" local
+    docker run --rm --name $containerName -p "${port}:8080" -v "${docsLocation}:/usr/local/structurizr" -e "STRUCTURIZR_WORKSPACE_MAXSIZE=$maxWorkspaceSize" "structurizr/structurizr:${version}" local
 } finally {
     Stop-Container
 }

--- a/architecture/scripts/run.sh
+++ b/architecture/scripts/run.sh
@@ -3,7 +3,7 @@
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 port=${1:-8080}
 version="${STCTZR_VERSION:-}"
-if [ -z "$version" ]; then version="2026.05.22"; fi
+if [ -z "$version" ]; then version="2026.06.28"; fi
 
 # Check if workspace.dsl file exists
 if [ ! -e "${docs_location}/workspace.dsl" ]; then

--- a/architecture/scripts/run.sh
+++ b/architecture/scripts/run.sh
@@ -4,6 +4,7 @@ docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 port=${1:-8080}
 version="${STCTZR_VERSION:-}"
 if [ -z "$version" ]; then version="2026.06.28"; fi
+max_workspace_size="${STCTZR_MAX_WORKSPACE_SIZE:-10MB}"
 
 # Check if workspace.dsl file exists
 if [ ! -e "${docs_location}/workspace.dsl" ]; then
@@ -24,5 +25,5 @@ trap cleanup SIGTERM SIGINT
 
 echo "Running workspace: ${docs_location} on port ${port}"
 
-docker run --rm --name "${container_name}" -p "${port}":8080 -v "${docs_location}:/usr/local/structurizr" "structurizr/structurizr:${version}" local &
+docker run --rm --name "${container_name}" -p "${port}":8080 -v "${docs_location}:/usr/local/structurizr" -e "STRUCTURIZR_WORKSPACE_MAXSIZE=${max_workspace_size}" "structurizr/structurizr:${version}" local &
 wait $!

--- a/architecture/scripts/update.ps1
+++ b/architecture/scripts/update.ps1
@@ -1,7 +1,7 @@
 $docsLocation = Split-Path -Parent $PSScriptRoot
 
 Write-Host "Updating workspace: $docsLocation"
-$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.05.22" }
+$version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "2026.06.28" }
 
 if (-not (Test-Path "$docsLocation\workspace.json")) {
     Write-Error "ERROR: workspace.json file not found in `"$docsLocation`" folder."

--- a/architecture/scripts/update.sh
+++ b/architecture/scripts/update.sh
@@ -3,7 +3,7 @@
 docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 echo "Updating workspace: ${docs_location}"
 version="${STCTZR_VERSION:-}"
-if [ -z "$version" ]; then version="2026.05.22"; fi
+if [ -z "$version" ]; then version="2026.06.28"; fi
 
 if [ ! -e "${docs_location}/workspace.json" ]; then
     echo "ERROR: workspace.json file not found in \"${docs_location}\" folder.";

--- a/lib/migrations/add-workspace-maxsize.migration.test.ts
+++ b/lib/migrations/add-workspace-maxsize.migration.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { file, write } from "bun";
+import { structurizrVersion } from "../utils/structurizr-version";
+import { addWorkspaceMaxSizeMigration } from "./add-workspace-maxsize.migration";
+
+const createTempDir = () =>
+    join(tmpdir(), `scaffoldizr-workspace-maxsize-test-${randomUUID()}`);
+
+// Only the server ("local") reads structurizr.workspace.maxsize, which
+// STRUCTURIZR_WORKSPACE_MAXSIZE sets, so the override belongs in run.* and
+// nowhere else.
+const serverScriptFiles = ["scripts/run.sh", "scripts/run.ps1"];
+
+const otherScriptFiles = [
+    "scripts/update.sh",
+    "scripts/update.ps1",
+    "scripts/export.sh",
+    "scripts/export.ps1",
+    "scripts/inspect.sh",
+    "scripts/inspect.ps1",
+];
+
+const allScriptFiles = [...serverScriptFiles, ...otherScriptFiles];
+
+const dummyContent = "# dummy placeholder content";
+
+const createTempDirWithExistingScripts = async (): Promise<string> => {
+    const testDir = createTempDir();
+    await mkdir(resolve(testDir, "scripts"), { recursive: true });
+    for (const relativePath of allScriptFiles) {
+        await write(resolve(testDir, relativePath), dummyContent);
+    }
+    return testDir;
+};
+
+describe("addWorkspaceMaxSizeMigration.apply", () => {
+    let testDir: string;
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    test("dryRun=true: returns applied=true with 8 filesChanged and does not write files", async () => {
+        testDir = await createTempDirWithExistingScripts();
+
+        const result = await addWorkspaceMaxSizeMigration.apply(
+            testDir,
+            testDir,
+            true,
+        );
+
+        expect(result.applied).toBe(true);
+        expect(result.filesChanged).toHaveLength(8);
+
+        for (const relativePath of allScriptFiles) {
+            const content = await file(resolve(testDir, relativePath)).text();
+            expect(content).toBe(dummyContent);
+        }
+    });
+
+    test("dryRun=false: regenerates all 8 scripts with the locked Structurizr version", async () => {
+        testDir = await createTempDirWithExistingScripts();
+
+        const result = await addWorkspaceMaxSizeMigration.apply(
+            testDir,
+            testDir,
+            false,
+        );
+
+        expect(result.applied).toBe(true);
+        expect(result.filesChanged).toHaveLength(8);
+
+        for (const relativePath of allScriptFiles) {
+            const content = await file(resolve(testDir, relativePath)).text();
+            expect(content).not.toBe(dummyContent);
+            expect(content).not.toContain("{{structurizrVersion}}");
+            expect(content).toContain(structurizrVersion);
+        }
+    });
+
+    test("adds the workspace max size override to the server scripts only", async () => {
+        testDir = await createTempDirWithExistingScripts();
+
+        await addWorkspaceMaxSizeMigration.apply(testDir, testDir, false);
+
+        for (const relativePath of serverScriptFiles) {
+            const content = await file(resolve(testDir, relativePath)).text();
+            expect(content).toContain("STRUCTURIZR_WORKSPACE_MAXSIZE");
+            expect(content).toContain("STCTZR_MAX_WORKSPACE_SIZE");
+            expect(content).toContain("10MB");
+        }
+
+        for (const relativePath of otherScriptFiles) {
+            const content = await file(resolve(testDir, relativePath)).text();
+            expect(content).not.toContain("STRUCTURIZR_WORKSPACE_MAXSIZE");
+            expect(content).not.toContain("STCTZR_MAX_WORKSPACE_SIZE");
+        }
+    });
+
+    test("is idempotent: applying twice produces identical file contents", async () => {
+        testDir = await createTempDirWithExistingScripts();
+
+        await addWorkspaceMaxSizeMigration.apply(testDir, testDir, false);
+
+        const contentsAfterFirstRun = await Promise.all(
+            allScriptFiles.map((relativePath) =>
+                file(resolve(testDir, relativePath)).text(),
+            ),
+        );
+
+        await addWorkspaceMaxSizeMigration.apply(testDir, testDir, false);
+
+        const contentsAfterSecondRun = await Promise.all(
+            allScriptFiles.map((relativePath) =>
+                file(resolve(testDir, relativePath)).text(),
+            ),
+        );
+
+        expect(contentsAfterSecondRun).toEqual(contentsAfterFirstRun);
+    });
+});

--- a/lib/migrations/add-workspace-maxsize.migration.test.ts
+++ b/lib/migrations/add-workspace-maxsize.migration.test.ts
@@ -4,7 +4,7 @@ import { mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { file, write } from "bun";
-import { structurizrVersion } from "../utils/structurizr-version";
+import { STRUCTURIZR_LOCKED_VERSION } from "../utils/structurizr-version";
 import { addWorkspaceMaxSizeMigration } from "./add-workspace-maxsize.migration";
 
 const createTempDir = () =>
@@ -78,7 +78,7 @@ describe("addWorkspaceMaxSizeMigration.apply", () => {
             const content = await file(resolve(testDir, relativePath)).text();
             expect(content).not.toBe(dummyContent);
             expect(content).not.toContain("{{structurizrVersion}}");
-            expect(content).toContain(structurizrVersion);
+            expect(content).toContain(STRUCTURIZR_LOCKED_VERSION);
         }
     });
 

--- a/lib/migrations/add-workspace-maxsize.migration.ts
+++ b/lib/migrations/add-workspace-maxsize.migration.ts
@@ -1,0 +1,108 @@
+import { chmod } from "node:fs/promises";
+import { resolve } from "node:path";
+import { file, write } from "bun";
+import chalk from "chalk";
+import templates from "../templates/bundle";
+import Handlebars from "../utils/handlebars";
+import { STRUCTURIZR_LOCKED_VERSION } from "../utils/structurizr-version";
+import type { Migration, MigrationResult } from "./types";
+
+const description =
+    "Regenerate scripts with the locked Structurizr version and workspace max size override";
+
+const filesChanged = [
+    "scripts/run.sh",
+    "scripts/run.ps1",
+    "scripts/update.sh",
+    "scripts/update.ps1",
+    "scripts/export.sh",
+    "scripts/export.ps1",
+    "scripts/inspect.sh",
+    "scripts/inspect.ps1",
+];
+
+const scriptEntries = [
+    {
+        key: "templates/scripts/run.sh",
+        relativePath: "scripts/run.sh",
+        executable: true,
+    },
+    {
+        key: "templates/scripts/run.ps1",
+        relativePath: "scripts/run.ps1",
+        executable: false,
+    },
+    {
+        key: "templates/scripts/update.sh",
+        relativePath: "scripts/update.sh",
+        executable: true,
+    },
+    {
+        key: "templates/scripts/update.ps1",
+        relativePath: "scripts/update.ps1",
+        executable: false,
+    },
+    {
+        key: "templates/scripts/export.sh",
+        relativePath: "scripts/export.sh",
+        executable: true,
+    },
+    {
+        key: "templates/scripts/export.ps1",
+        relativePath: "scripts/export.ps1",
+        executable: false,
+    },
+    {
+        key: "templates/scripts/inspect.sh",
+        relativePath: "scripts/inspect.sh",
+        executable: true,
+    },
+    {
+        key: "templates/scripts/inspect.ps1",
+        relativePath: "scripts/inspect.ps1",
+        executable: false,
+    },
+];
+
+export const addWorkspaceMaxSizeMigration: Migration = {
+    fromVersion: "0.0.0",
+    toVersion: "0.16.0",
+    description,
+    async apply(
+        workspacePath: string,
+        _destPath: string,
+        dryRun: boolean,
+    ): Promise<MigrationResult> {
+        for (const entry of scriptEntries) {
+            const templatePath = templates.get(entry.key);
+            if (!templatePath) {
+                throw new Error(`Template not found in bundle: ${entry.key}`);
+            }
+            const rawContent = await file(templatePath).text();
+            const content = Handlebars.compile(rawContent)({
+                structurizrVersion: STRUCTURIZR_LOCKED_VERSION,
+            });
+            const absolutePath = resolve(workspacePath, entry.relativePath);
+
+            if (dryRun) {
+                console.log(
+                    chalk.gray(
+                        `[DRY RUN]: Would overwrite ${entry.relativePath}`,
+                    ),
+                );
+            } else {
+                await write(absolutePath, content);
+                if (entry.executable) {
+                    await chmod(absolutePath, 0o744);
+                }
+                console.log(chalk.gray(`[UPDATED]: ${entry.relativePath}`));
+            }
+        }
+
+        return {
+            applied: true,
+            description,
+            filesChanged,
+        };
+    },
+};

--- a/lib/migrations/registry.ts
+++ b/lib/migrations/registry.ts
@@ -1,5 +1,6 @@
 import { addStandaloneScriptsMigration } from "./add-standalone-scripts.migration";
 import { addVersionHeaderMigration } from "./add-version-header.migration";
+import { addWorkspaceMaxSizeMigration } from "./add-workspace-maxsize.migration";
 import { regenerateScriptsMigration } from "./regenerate-scripts.migration";
 import type { Migration } from "./types";
 
@@ -7,4 +8,5 @@ export const migrations: Migration[] = [
     addVersionHeaderMigration,
     regenerateScriptsMigration,
     addStandaloneScriptsMigration,
+    addWorkspaceMaxSizeMigration,
 ];

--- a/lib/templates/scripts/run.ps1
+++ b/lib/templates/scripts/run.ps1
@@ -1,6 +1,7 @@
 $docsLocation = Split-Path -Parent $PSScriptRoot
 $port = if ($args[0]) { $args[0] } else { 8080 }
 $version = if ($env:STCTZR_VERSION) { $env:STCTZR_VERSION } else { "{{structurizrVersion}}" }
+$maxWorkspaceSize = if ($env:STCTZR_MAX_WORKSPACE_SIZE) { $env:STCTZR_MAX_WORKSPACE_SIZE } else { "10MB" }
 
 if (-not (Test-Path "$docsLocation\workspace.dsl")) {
     Write-Error "ERROR: workspace.dsl file not found in `"$docsLocation`" folder."
@@ -20,7 +21,7 @@ function Stop-Container {
 Write-Host "Running workspace: $docsLocation on port $port"
 
 try {
-    docker run --rm --name $containerName -p "${port}:8080" -v "${docsLocation}:/usr/local/structurizr" "structurizr/structurizr:${version}" local
+    docker run --rm --name $containerName -p "${port}:8080" -v "${docsLocation}:/usr/local/structurizr" -e "STRUCTURIZR_WORKSPACE_MAXSIZE=$maxWorkspaceSize" "structurizr/structurizr:${version}" local
 } finally {
     Stop-Container
 }

--- a/lib/templates/scripts/run.sh
+++ b/lib/templates/scripts/run.sh
@@ -4,6 +4,7 @@ docs_location=$(cd "$(dirname "${0}")" && cd .. && pwd)
 port=${1:-8080}
 version="${STCTZR_VERSION:-}"
 if [ -z "$version" ]; then version="{{structurizrVersion}}"; fi
+max_workspace_size="${STCTZR_MAX_WORKSPACE_SIZE:-10MB}"
 
 # Check if workspace.dsl file exists
 if [ ! -e "${docs_location}/workspace.dsl" ]; then
@@ -24,5 +25,5 @@ trap cleanup SIGTERM SIGINT
 
 echo "Running workspace: ${docs_location} on port ${port}"
 
-docker run --rm --name "${container_name}" -p "${port}":8080 -v "${docs_location}:/usr/local/structurizr" "structurizr/structurizr:${version}" local &
+docker run --rm --name "${container_name}" -p "${port}":8080 -v "${docs_location}:/usr/local/structurizr" -e "STRUCTURIZR_WORKSPACE_MAXSIZE=${max_workspace_size}" "structurizr/structurizr:${version}" local &
 wait $!

--- a/lib/utils/structurizr-version.ts
+++ b/lib/utils/structurizr-version.ts
@@ -1,4 +1,4 @@
-export const STRUCTURIZR_LOCKED_VERSION = "2026.05.22";
+export const STRUCTURIZR_LOCKED_VERSION = "2026.06.28";
 
 export const structurizrVersion =
     process.env.STCTZR_VERSION ?? STRUCTURIZR_LOCKED_VERSION;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@formula-monks/scaffoldizr",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "description": "Opinionated TypeScript/Bun Scaffolding Tool for creating Structurizr DSL Documentations",
     "module": "src/main.mjs",
     "bin": {


### PR DESCRIPTION
## Summary

Structurizr refuses to load a workspace larger than `structurizr.workspace.maxsize`, which defaults to **1MB** upstream — a limit a moderately sized C4 model exceeds. This makes the limit configurable and bumps the locked Structurizr image to `2026.06.28`.

| Commit | Change |
| :----- | :----- |
| `chore(structurizr)` | Bump `STRUCTURIZR_LOCKED_VERSION` to `2026.06.28`, regenerating the pinned image tag in `architecture/scripts/*` and the CLI skill docs. |
| `feat(scripts)` | `run.sh` / `run.ps1` pass `STRUCTURIZR_WORKSPACE_MAXSIZE` to the container, defaulting to `10MB` and overridable with `STCTZR_MAX_WORKSPACE_SIZE`. |
| `chore(release)` | Bump `package.json` to `0.16.0`. |
| `feat(migrations)` | A `0.16.0` migration re-renders all eight workspace scripts from the bundled templates, so existing workspaces pick up both the override and the new image tag. |
| `docs(usage)` | Document `STCTZR_MAX_WORKSPACE_SIZE` and `STCTZR_VERSION` — neither was documented before. |
| `docs(migrate)` | The bundled migration list stopped at the first two migrations; document `add-standalone-scripts` and the new max size migration. |

The release bump precedes the migration commit deliberately: `scfzVersion` is read from `package.json`, and `index.test.ts` asserts no migration's `toVersion` exceeds it, so the opposite order leaves a red commit.

## Why only the run scripts?

Verified against the upstream implementation rather than assumed. `structurizr.workspace.maxsize` is defined in [`StructurizrProperties`](https://github.com/structurizr/structurizr/blob/main/structurizr-application/src/main/java/com/structurizr/configuration/StructurizrProperties.java) (`DEFAULT_MAX_WORKSPACE_SIZE = "1MB"`) and is read in exactly two places:

- `com.structurizr.server.component.workspace.WorkspaceComponentImpl`
- `com.structurizr.playground.PlaygroundController`

Both are web-application paths. Nothing in `com.structurizr.command.*` — `ExportCommand`, `InspectCommand`, `ValidateCommand`, `ListCommand`, `PushCommand` — consults it, and upstream documents the setting only under the [`local`](https://docs.structurizr.com/local/configuration) and `server` command configuration pages. So `export.*`, `inspect.*` and `update.*` correctly leave it unset; for `update` (push), the limit that applies is the one configured on the receiving server. A test asserts the override appears in `run.*` and in none of the other six scripts.

`STRUCTURIZR_WORKSPACE_MAXSIZE` is upstream's documented environment-variable form of the property. It is preferred over `-Dstructurizr.workspace.maxsize` via `JAVA_TOOL_OPTIONS`, which would print "Picked up JAVA_TOOL_OPTIONS" to stderr on every run and clobber any `JAVA_TOOL_OPTIONS` the user had set.

## Testing

- `bun test` at **each of the six commits**: 175 → 179 pass, 0 fail throughout.
- New migration covered at 100% funcs / 98.99% lines: dry-run, regeneration, "override in the server scripts only", and idempotency.
- `biome check` clean on the changed TypeScript.
- `tsc --noEmit` reports only pre-existing errors in vendored `dist/html/js/joint-3.6.5.js`, untouched here.

## Notes for reviewers

- `10MB` is a deliberate default rather than upstream's `1MB`, so a typical workspace loads out of the box; `STCTZR_MAX_WORKSPACE_SIZE` overrides it without regenerating scripts. The usage docs note that very large workspaces degrade browser rendering and that splitting across workspaces beats raising the limit indefinitely.
- The `run`-only scoping is asserted by a test, so a future change that adds the override to `export`/`inspect`/`update` will fail loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
